### PR TITLE
migrate to jdk 22 and fix upcalls

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -72,8 +72,8 @@
                   :src-dirs source-dirs})
     (b/copy-file {:src (b/pom-path {:lib lib-coord
                                     :class-dir class-dir})
-                  :target (str target-dir "pom.xml")})
-    opts))
+                  :target (str target-dir "pom.xml")}))
+  opts)
 
 (defn pom
   "Generates a `pom.xml` file in the `target/classes/META-INF` directory.
@@ -118,8 +118,8 @@
     (.mkdirs (io/file target-dir))
     (b/process {:command-args (concat ["clang" "-fpic" "-shared"]
                                       c-files
-                                      ["-o" test-c-library])})
-    opts))
+                                      ["-o" test-c-library])}))
+  opts)
 
 (defn run-tasks
   "Runs a series of tasks with a set of options.

--- a/build.clj
+++ b/build.clj
@@ -134,3 +134,19 @@
   [opts]
   (binding [*ns* (find-ns 'build)]
     (run! (call-optionally-with opts) (:tasks opts))))
+
+
+(def prep-all ['compile-java 'compile-test-library])
+
+(comment
+
+  (compile-java)
+
+  (compile-test-library)
+
+  (run-tasks prep-all)
+
+  (compile-test-library)
+
+)
+

--- a/build.clj
+++ b/build.clj
@@ -52,8 +52,8 @@
   (b/process {:command-args ["javac" "--enable-preview"
                              "src/java/coffi/ffi/Loader.java"
                              "-d" class-dir
-                             "-target" "21"
-                             "-source" "21"]})
+                             "-target" "22"
+                             "-source" "22"]})
   opts)
 
 (defn- write-pom

--- a/build.clj
+++ b/build.clj
@@ -92,7 +92,7 @@
   "Generates a `coffi.jar` file in the `target/` directory.
   This is a thin jar including only the sources."
   [opts]
-  (write-pom opts)
+  (write-pom)
   (compile-java)
   (copy-resources)
   (when-not (exists? target-dir jar-file)

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src/clj" "target/classes" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        insn/insn {:mvn/version "0.2.1"}}
+        insn/insn {:mvn/version "0.5.4"}}
 
  :deps/prep-lib {:alias :build
                  :fn build/compile-java

--- a/src/clj/coffi/ffi.clj
+++ b/src/clj/coffi/ffi.clj
@@ -292,7 +292,7 @@
 
                  ;; cast null pointers to something understood by panama
                  (#{::mem/pointer} type)
-                 `(or ~sym (MemoryAddress/NULL))
+                 `(or ~sym (MemorySegment/NULL))
 
                  (mem/primitive-type type)
                  `(mem/serialize* ~sym ~type-sym ~session)

--- a/src/clj/coffi/ffi.clj
+++ b/src/clj/coffi/ffi.clj
@@ -499,10 +499,6 @@
                                     inc)))
                          acc))
                      [:invokeinterface IFn "invoke" (repeat (inc (count arg-types)) Object)]
-                     (if (identical? ::mem/pointer (mem/primitive-type ret-type))
-                       [[:checkcast Long]
-                        [:invokevirtual Long "longValue" [:long]]
-                        [:invokestatic MemorySegment "ofAddress" [:long MemorySegment] true]])
                      (to-prim-asm ret-type)
                      [(return-for-type ret-type :areturn)]]}]})
 

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1247,15 +1247,15 @@
   ::pointer)
 
 (defmethod serialize* ::c-string
-  [obj _type session]
+  [obj _type ^Arena session]
   (if obj
-    (address-of (.allocateUtf8String (arena-allocator session) ^String obj))
+    (address-of (.allocateFrom session ^String obj))
     (MemorySegment/NULL)))
 
 (defmethod deserialize* ::c-string
   [addr _type]
   (when-not (null? addr)
-    (.getUtf8String (.reinterpret ^MemorySegment addr Integer/MAX_VALUE) 0)))
+    (.getString (.reinterpret ^MemorySegment addr Integer/MAX_VALUE) 0)))
 
 ;;; Union types
 

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1247,7 +1247,7 @@
 (defmethod serialize* ::c-string
   [obj _type ^Arena session]
   (if obj
-    (address-of (.allocateFrom session ^String obj))
+    (.allocateFrom session ^String obj)
     (MemorySegment/NULL)))
 
 (defmethod deserialize* ::c-string

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -269,8 +269,6 @@
   (.addCloseAction session action)
   nil)
 
-;; TODO(Joshua): Determine if this needs to exist at all
-#_
 (defn as-segment
   "Dereferences an `address` into a memory segment associated with the `session`."
   (^MemorySegment [^MemoryAddress address size]

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -271,10 +271,10 @@
 
 (defn as-segment
   "Dereferences an `address` into a memory segment associated with the `session`."
-  (^MemorySegment [^MemoryAddress address size]
-   (MemorySegment/ofAddress address (long size) (connected-session)))
-  (^MemorySegment [^MemoryAddress address size session]
-   (MemorySegment/ofAddress address (long size) session)))
+  (^MemorySegment [^MemorySegment address size]
+   (.reinterpret (MemorySegment/ofAddress address) (long size) (connected-session) nil))
+  (^MemorySegment [^MemorySegment address size session]
+   (.reinterpret (MemorySegment/ofAddress address) (long size) session nil)))
 
 (defn copy-segment
   "Copies the content to `dest` from `src`.

--- a/test/c/ffi_test.c
+++ b/test/c/ffi_test.c
@@ -39,35 +39,41 @@ char* upcall_test_int_fn_string_ret(int (*f)(void)) {
 }
 
 CString get_string1(void) {
-    return responses[counter++ % 3];
+  return responses[counter++ % 3];
 }
 
 CString get_string2(void) {
-    return "Alternate string";
+  return "Alternate string";
 }
 
 StringFactory get_downcall(int whichString) {
-    switch (whichString % 2) {
-    case 0:
-        return get_string1;
-    case 1:
-        return get_string2;
-    default:
-        return 0;
-    }
+  switch (whichString % 2) {
+  case 0:
+    return get_string1;
+  case 1:
+    return get_string2;
+  default:
+    return 0;
+  }
 }
 
 typedef struct alignment_test {
-    char a;
-    double x;
-    float y;
+  char a;
+  double x;
+  float y;
 } AlignmentTest;
 
 AlignmentTest get_struct() {
-    AlignmentTest ret = {};
-    ret.a = 'x';
-    ret.x = 3.14;
-    ret.y = 42.0;
+  AlignmentTest ret = {};
+  ret.a = 'x';
+  ret.x = 3.14;
+  ret.y = 42.0;
 
-    return ret;
+  return ret;
 }
+
+void test_call_with_trailing_string_arg(int a, int b, char* text) {
+  printf("call of `test_call_with_trailing_string_arg` with a=%i b=%i text='%s'",a,b,text);
+  return;
+}
+

--- a/test/c/ffi_test.c
+++ b/test/c/ffi_test.c
@@ -26,9 +26,17 @@ CString upcall_test(StringFactory fun) {
     return fun();
 }
 
+int upcall_test2(int (*f)(void)) {
+    return f();
+}
+
 int counter = 0;
 
 static char* responses[] = { "Hello, world!", "Goodbye friend.", "co'oi prenu" };
+
+char* upcall_test_int_fn_string_ret(int (*f)(void)) {
+    return responses[f()];
+}
 
 CString get_string1(void) {
     return responses[counter++ % 3];

--- a/test/c/ffi_test.c
+++ b/test/c/ffi_test.c
@@ -73,7 +73,8 @@ AlignmentTest get_struct() {
 }
 
 void test_call_with_trailing_string_arg(int a, int b, char* text) {
-  printf("call of `test_call_with_trailing_string_arg` with a=%i b=%i text='%s'",a,b,text);
+  printf("call of `test_call_with_trailing_string_arg` with a=%i b=%i text='%s'",1,2,text);
+  printf("\r                                                                          ");
   return;
 }
 

--- a/test/clj/coffi/ffi_test.clj
+++ b/test/clj/coffi/ffi_test.clj
@@ -59,3 +59,12 @@
   (ffi/freset! (ffi/static-variable "counter" ::mem/int) 1)
   (t/is (= ((ffi/cfn "get_string1" [] ::mem/c-string))
            "Goodbye friend.")))
+
+(t/deftest can-call-with-trailing-string-arg
+  (t/is
+   (=
+    ((ffi/cfn "test_call_with_trailing_string_arg"
+              [::mem/int ::mem/int ::mem/c-string]
+              ::mem/void)
+     1 2 "third arg")
+           )))

--- a/test/clj/coffi/ffi_test.clj
+++ b/test/clj/coffi/ffi_test.clj
@@ -29,12 +29,12 @@
 
 (t/deftest can-make-upcall
   (t/is (= ((ffi/cfn "upcall_test" [[::ffi/fn [] ::mem/c-string]] ::mem/c-string)
-            (fn [] "hello"))
-           "hello")))
+            (fn [] "hello from clojure from c from clojure"))
+           "hello from clojure from c from clojure")))
 
 (t/deftest can-make-upcall2
   (t/is (= ((ffi/cfn "upcall_test2" [[::ffi/fn [] ::mem/int]] ::mem/int)
-            (fn [] 6))
+            (fn [] 5))
            5)))
 
 (t/deftest can-make-upcall-int-fn-string-ret

--- a/test/clj/coffi/ffi_test.clj
+++ b/test/clj/coffi/ffi_test.clj
@@ -32,6 +32,16 @@
             (fn [] "hello"))
            "hello")))
 
+(t/deftest can-make-upcall2
+  (t/is (= ((ffi/cfn "upcall_test2" [[::ffi/fn [] ::mem/int]] ::mem/int)
+            (fn [] 6))
+           5)))
+
+(t/deftest can-make-upcall-int-fn-string-ret
+  (t/is (= ((ffi/cfn "upcall_test_int_fn_string_ret" [[::ffi/fn [] ::mem/int]] ::mem/c-string)
+            (fn [] 2))
+           "co'oi prenu")))
+
 (mem/defalias ::alignment-test
   (layout/with-c-layout
     [::mem/struct

--- a/test/clj/coffi/ffi_test.clj
+++ b/test/clj/coffi/ffi_test.clj
@@ -66,5 +66,5 @@
     ((ffi/cfn "test_call_with_trailing_string_arg"
               [::mem/int ::mem/int ::mem/c-string]
               ::mem/void)
-     1 2 "third arg")
-           )))
+     1 2 "third arg"))))
+

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -1,0 +1,32 @@
+(ns coffi.mem-test
+  (:require
+   [clojure.test :as t]
+   [coffi.ffi :as ffi]
+   [coffi.layout :as layout]
+   [coffi.mem :as mem])
+  (:import
+   (java.lang.foreign
+    AddressLayout
+    Arena
+    MemoryLayout
+    MemorySegment
+    MemorySegment$Scope
+    SegmentAllocator
+    ValueLayout
+    ValueLayout$OfByte
+    ValueLayout$OfShort
+    ValueLayout$OfInt
+    ValueLayout$OfLong
+    ValueLayout$OfChar
+    ValueLayout$OfFloat
+    ValueLayout$OfDouble)
+   (java.lang.ref Cleaner)
+   (java.nio ByteOrder)))
+
+(ffi/load-library "target/ffi_test.so")
+
+(t/deftest can-serialize-string
+  (t/is
+   (instance? MemorySegment (mem/serialize "this is a string" ::mem/c-string))))
+
+


### PR DESCRIPTION
Hi, in this pull request I propose migrating the project to jdk22 support.

I also managed to track down the reason the upcall test failed.
After adding tests for other upcalls i noticed, it only failed for jvm functions that return strings.

I eventually inserted a few debug prints into the generated bytecode of upcall-class and downcall-class and saw this:

```
("downcall-fn called")
hello from downcall-class/invoke
to prim-asm of supposed type [:coffi.ffi/fn [] :coffi.mem/c-string]. actual class of value:
jdk.internal.foreign.NativeMemorySegmentImpl
hello from downcall-class before invokeExact
hello from upcall-class/upcall
hello from upcall-class right before the invoke
hello from upcall-class right after the invoke
to prim-asm of supposed return type :coffi.mem/c-string. actual class of value:
java.lang.Long
java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.foreign.MemorySegment (java.lang.Long and java.lang.foreign.MemorySegment are in module java.base of loader 'bootstrap')
```

Turns out the downcall function that is wrapped by downcall-class correctly handles the function argument as a MemorySegment (thus not necessitating any to-prim-asm conversion), but the function wrapped by upcall-class returns a Long for the ret-type `::mem/c-string`. I'm not entirely sure if that's the case for any value that has `primitive-type` of `::mem/pointer` but I suspect that's the case.

Because of that a simple change to `to-prim-asm` didn't work since it would have to behave differently for upcall-class and downcall-class.

The solution I've settled on in this pull request is to still let upcall-class/upcall use the `to-prim-asm` instructions but also for specifically pointer types call `MemorySegment.ofAddress`. There is a downside to doing that though. Since this is a default static method of an Interface, calling it from bytecode necessitates a higher bytecode version than is default. Version 8 is fine, but it needs to be specified on the generated class. I've also bumped the insn version to 0.5.4 which allows emitting more recent jvm bytecode versions should that be necessary. In any case, with that change we can `invokestatic` with the extra argument `true`, which sets ASMs `itf` flag so we can specify that we're talking about an InterfaceMethodref and successfully call the interface method directly from bytecode.

I'm not exactly sure if the function wrapped by upcall-class shouldn't just return a MemorySegment in the first place instead of a Long, but i wasn't sure how to robustly integrate this.

The reason it does so, is because of how `serialize` is implemented for `c-string`. In migrating to the jdk22 API, I kept the old behavior, which simply returns the address of the string as a Long. I'm not sure if other parts of the library depend on that specific behavior, so the additional call to `MemorySegment.ofAddress` seemed like the pragmatic choice to me. 

Any feedback on this?