### PR TITLE
Support named union members in c-layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- Add support for named union members in c-layout
 
 ## [1.0.486] - 2024-10-04
 ### Fixed

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1149,7 +1149,12 @@
 
 (defmethod c-layout ::union
   [[_union types & {:as _opts} :as _type]]
-  (let [items (map c-layout types)]
+  (let [items (if (map? types)
+                (map
+                  (fn [[field-name field]]
+                    (.withName ^MemoryLayout (c-layout field) (name field-name)))
+                  types)
+                (map c-layout types))]
     (MemoryLayout/unionLayout
      (into-array MemoryLayout items))))
 


### PR DESCRIPTION
Previously one could only use a set to describe the types of a union:
```clojure
(mem/c-layout
  [::mem/union
   #{::mem/int ::mem/c-string}])

; => #object[jdk.internal.foreign.layout.UnionLayoutImpl 0x6a212343 "[i4|a8]"]
```
This (small) PR adds the ability to pass a map of names to types: 
```clojure
(mem/c-layout
  [::mem/union
   {:ok ::mem/int :err ::mem/c-string}])
;=> #object[jdk.internal.foreign.layout.UnionLayoutImpl 0x2b27b44d "[i4(ok)|a8(err)]"]
```

This just exposes the [java.lang.foreign.MemoryLayout/withName](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/foreign/MemoryLayout.html#withName(java.lang.String)) method inside of union member definitions. 

These names can be useful for advanced/lower level usage of the `MemoryLayouts`.  In particular when trying to automatically generate coffi implementations from C header files, we might not want to discard this type of metadata. (Jextract does keep the names in the layout for what it's worth).

Note that any `MemoryLayout` can have a name, so it's potentially worth supporting more generally. It could be useful for example in function arguments. However since (I believe) union members MUST have a name, the omission is more glaring, and users could always add their own `::named` type to support it elsewhere if desired.
