### PR TITLE
Add defstruct macro

### DIFF
--- a/src/clj/coffi/layout.clj
+++ b/src/clj/coffi/layout.clj
@@ -3,8 +3,29 @@
   (:require
    [coffi.mem :as mem]))
 
-(def with-c-layout
-  @#'mem/with-c-layout)
-(alter-meta! #'with-c-layout #(merge (-> (meta #'mem/with-c-layout)
-                                         (dissoc :private))
-                                     %))
+(defn with-c-layout
+  "Forces a struct specification to C layout rules.
+
+  This will add padding fields between fields to match C alignment
+  requirements."
+  [struct-spec]
+  (let [aligned-fields
+        (loop [offset 0
+               aligned-fields []
+               fields (nth struct-spec 1)]
+          (if (seq fields)
+            (let [[[_ type :as field] & fields] fields
+                  size (mem/size-of type)
+                  align (mem/align-of type)
+                  r (rem offset align)]
+              (recur (cond-> (+ offset size)
+                       (pos? r) (+ (- align r)))
+                     (cond-> aligned-fields
+                       (pos? r) (conj [:coffi.layout/padding [:coffi.mem/padding (- align r)]])
+                       :always (conj field))
+                     fields))
+            (let [strongest-alignment (reduce max (map (comp mem/align-of second) (nth struct-spec 1)))
+                  r (rem offset strongest-alignment)]
+              (cond-> aligned-fields
+                (pos? r) (conj [:coffi.layout/padding [:coffi.mem/padding (- strongest-alignment r)]])))))]
+    (assoc struct-spec 1 aligned-fields)))

--- a/src/clj/coffi/layout.clj
+++ b/src/clj/coffi/layout.clj
@@ -3,29 +3,8 @@
   (:require
    [coffi.mem :as mem]))
 
-(defn with-c-layout
-  "Forces a struct specification to C layout rules.
-
-  This will add padding fields between fields to match C alignment
-  requirements."
-  [struct-spec]
-  (let [aligned-fields
-        (loop [offset 0
-               aligned-fields []
-               fields (nth struct-spec 1)]
-          (if (seq fields)
-            (let [[[_ type :as field] & fields] fields
-                  size (mem/size-of type)
-                  align (mem/align-of type)
-                  r (rem offset align)]
-              (recur (cond-> (+ offset size)
-                       (pos? r) (+ (- align r)))
-                     (cond-> aligned-fields
-                       (pos? r) (conj [::padding [::mem/padding (- align r)]])
-                       :always (conj field))
-                     fields))
-            (let [strongest-alignment (reduce max (map (comp mem/align-of second) (nth struct-spec 1)))
-                  r (rem offset strongest-alignment)]
-              (cond-> aligned-fields
-                (pos? r) (conj [::padding [::mem/padding (- strongest-alignment r)]])))))]
-    (assoc struct-spec 1 aligned-fields)))
+(def with-c-layout
+  @#'mem/with-c-layout)
+(alter-meta! #'with-c-layout #(merge (-> (meta #'mem/with-c-layout)
+                                         (dissoc :private))
+                                     %))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -658,199 +658,164 @@
    (.set segment ^AddressLayout pointer-layout offset value)))
 
 (defn write-bytes
-  "Writes a [[byte]] array to the `segment`, at an optional `offset`."
+  "Writes n elements from a [[byte]] array to the `segment`, at an optional `offset`."
   {:inline
    (fn write-byte-inline
-     ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (MemorySegment/copy value# 0  ^MemorySegment segment# ^ValueLayout$OfByte byte-layout 0 ^int (alength value#))))
-     ([segment offset value]
-      `(let [segment# ~segment
+     ([segment n value]
+      `(let [n# ~n
+             segment# ~segment
+             value# ~(with-meta value {:tag 'bytes})]
+         (MemorySegment/copy value# 0  ^MemorySegment segment# ^ValueLayout$OfByte byte-layout 0 n#)))
+     ([segment n offset value]
+      `(let [n# ~n
+             segment# ~segment
              offset# ~offset
-             value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfByte byte-layout offset# ^int (alength value#)))))}
-  ([^MemorySegment segment ^bytes value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfByte byte-layout 0 (alength value)))
-  ([^MemorySegment segment offset ^bytes value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfByte byte-layout ^long offset ^int (alength value))))
+             value# ~(with-meta value {:tag 'bytes})]
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfByte byte-layout offset# n#))))}
+  ([^MemorySegment segment n ^bytes value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfByte byte-layout 0 ^int n))
+  ([^MemorySegment segment n offset ^bytes value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfByte byte-layout ^long offset ^int n)))
 
 (defn write-shorts
-  "Writes a [[short]] array to the `segment`, at an optional `offset`.
+  "Writes n elements from a [[short]] array to the `segment`, at an optional `offset`.
 
   If `byte-order` is not provided, it defaults to [[native-endian]]."
   {:inline
    (fn write-shorts-inline
-     ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfShort short-layout 0 ^int (alength value#))))
-     ([segment offset value]
-      `(let [segment# ~segment
+     ([segment n value]
+      `(let [n# ~n
+             segment# ~segment
+             value# ~(with-meta value {:tag 'shorts})]
+         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfShort short-layout 0 n#)))
+     ([segment n offset value]
+      `(let [n# ~n
+             segment# ~segment
              offset# ~offset
-             value# ~value]
-         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfShort short-layout ^long offset# ^int (alength value#))))
-     ([segment offset byte-order value]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order
-             value# ~value]
-         (MemorySegment/copy value# 0 segment# (.withOrder ^ValueLayout$OfShort short-layout ^ByteOrder byte-order#) ^long offset# ^int (alength value#)))))}
-  ([^MemorySegment segment ^shorts value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfShort short-layout 0 (alength value)))
-  ([^MemorySegment segment ^long offset ^shorts value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfShort short-layout ^long offset (alength value)))
-  ([^MemorySegment segment ^long offset ^ByteOrder byte-order ^shorts value]
-   (MemorySegment/copy value 0 segment (.withOrder ^ValueLayout$OfShort short-layout byte-order) ^long offset (alength value))))
+             value# ~(with-meta value {:tag 'shorts})]
+         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfShort short-layout ^long offset# n#))))}
+  ([^MemorySegment segment n ^shorts value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfShort short-layout 0 ^int n))
+  ([^MemorySegment segment n ^long offset ^shorts value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfShort short-layout ^long offset ^int n)))
 
 (defn write-ints
-  "Writes a [[int]] array to the `segment`, at an optional `offset`.
+  "Writes n elements from an [[int]] array to the `segment`, at an optional `offset`.
 
   If `byte-order` is not provided, it defaults to [[native-endian]]."
   {:inline
    (fn write-ints-inline
-     ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfInt int-layout 0 ^{:tag 'int} (alength value#))
-         ))
-     ([segment offset value]
-      `(let [segment# ~segment
+     ([segment n value]
+      `(let [n# ~n
+             segment# ~segment
+             value# ~(with-meta value {:tag 'shorts})]
+         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfInt int-layout 0 n#)))
+     ([segment n offset value]
+      `(let [n# ~n
+             segment# ~segment
              offset# ~offset
-             value# ~value]
-         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfInt int-layout ^long offset# ^{:tag 'int} (alength value#))
-         ))
-     ([segment offset byte-order value]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order
-             value# ~value]
-         (MemorySegment/copy value# 0 segment# (.withOrder ^ValueLayout$OfInt int-layout ^ByteOrder byte-order#) ^long offset# ^{:tag 'int} (alength value#)))))}
-  ([^MemorySegment segment ^ints value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfInt int-layout 0 (alength value)))
-  ([^MemorySegment segment ^long offset ^ints value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfInt int-layout ^long offset (alength value)))
-  ([^MemorySegment segment ^long offset ^ByteOrder byte-order ^ints value]
-   (MemorySegment/copy value 0 segment (.withOrder ^ValueLayout$OfInt int-layout byte-order) ^long offset (alength value))))
+             value# ~(with-meta value {:tag 'shorts})]
+         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfInt int-layout ^long offset# n#)))
+     )}
+  ([^MemorySegment segment n ^ints value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfInt int-layout 0 ^int n))
+  ([^MemorySegment segment n ^long offset ^ints value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfInt int-layout ^long offset ^int n))
+  )
 
 (defn write-longs
-  "Writes a [[long]] array to the `segment`, at an optional `offset`.
+  "Writes n elements from a [[long]] array to the `segment`, at an optional `offset`.
 
   If `byte-order` is not provided, it defaults to [[native-endian]]."
   {:inline
    (fn write-longs-inline
-     ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfLong long-layout 0 ^{:tag 'int} (alength value#))
+     ([segment n value]
+      `(let [n# ~n
+             segment# ~segment
+             value# ~(with-meta value {:tag 'longs})]
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfLong long-layout 0 n#)
          ))
-     ([segment offset value]
-      `(let [segment# ~segment
+     ([segment n offset value]
+      `(let [n# ~n
+             segment# ~segment
              offset# ~offset
-             value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfLong long-layout ^long offset# ^{:tag 'int} (alength value#))
+             value# ~(with-meta value {:tag 'longs})]
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfLong long-layout ^long offset# n#)
          ))
-     ([segment offset byte-order value]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order
-             value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# (.withOrder ^ValueLayout$OfLong long-layout ^ByteOrder byte-order#) ^long offset# ^{:tag 'int} (alength value#)))))}
-  ([^MemorySegment segment ^longs value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfLong long-layout 0 ^int (alength value)))
-  ([^MemorySegment segment ^long offset ^longs value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfLong long-layout ^long offset ^int (alength value)))
-  ([^MemorySegment segment ^long offset ^ByteOrder byte-order ^longs value]
-   (MemorySegment/copy value 0 segment (.withOrder ^ValueLayout$OfLong long-layout byte-order) ^long offset ^int (alength value))))
+     )}
+  ([^MemorySegment segment n ^longs value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfLong long-layout 0 ^int n))
+  ([^MemorySegment segment n ^long offset ^longs value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfLong long-layout ^long offset ^int n))
+  )
 
 
 (defn write-chars
-  "Writes a [[char]] array to the `segment`, at an optional `offset`.
+  "Writes n elements from a [[char]] array to the `segment`, at an optional `offset`.
 
   If `byte-order` is not provided, it defaults to [[native-endian]]."
   {:inline
    (fn write-chars-inline
-     ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# ^ValueLayout$OfChar char-layout 0 ^{:tag 'int} (alength value#))))
-     ([segment offset value]
-      `(let [segment# ~segment
+     ([segment n value]
+      `(let [n# ~n
+             segment# ~segment
+             value# ~(with-meta value {:tag 'chars})]
+         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# ^ValueLayout$OfChar char-layout 0 n#)))
+     ([segment n offset value]
+      `(let [n# ~n
+             segment# ~segment
              offset# ~offset
-             value# ~value]
-         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# ^ValueLayout$OfChar char-layout ^long offset# ^{:tag 'int} (alength value#))))
-     ([segment offset byte-order value]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order
-             value# ~value]
-         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# (.withOrder ^ValueLayout$OfChar char-layout ^ByteOrder byte-order#) ^long offset# ^{:tag 'int} (alength value#)))))}
-  ([^MemorySegment segment ^chars value]
-   (MemorySegment/copy (bytes (byte-array (map unchecked-int value))) 0 segment ^ValueLayout$OfChar char-layout 0 (alength value)))
-  ([^MemorySegment segment ^long offset ^chars value]
-   (MemorySegment/copy (bytes (byte-array (map unchecked-int value))) 0 segment ^ValueLayout$OfChar char-layout ^long offset (alength value)))
-  ([^MemorySegment segment ^long offset ^ByteOrder byte-order ^chars value]
-   (MemorySegment/copy (bytes (byte-array (map unchecked-int value))) 0 segment (.withOrder ^ValueLayout$OfChar char-layout byte-order) ^long offset (alength value))))
+             value# ~(with-meta value {:tag 'chars})]
+         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# ^ValueLayout$OfChar char-layout ^long offset# n#)))
+     )}
+  ([^MemorySegment segment n ^chars value]
+   (MemorySegment/copy (bytes (byte-array (map unchecked-int value))) 0 segment ^ValueLayout$OfChar char-layout 0 ^int n))
+  ([^MemorySegment segment n ^long offset ^chars value]
+   (MemorySegment/copy (bytes (byte-array (map unchecked-int value))) 0 segment ^ValueLayout$OfChar char-layout ^long offset ^int n )))
 
 (defn write-floats
-  "Writes a [[float]] array to the `segment`, at an optional `offset`.
+  "Writes n elements from a [[float]] array to the `segment`, at an optional `offset`.
 
   If `byte-order` is not provided, it defaults to [[native-endian]]."
   {:inline
    (fn write-floats-inline
-     ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfFloat float-layout 0 ^{:tag 'int} (alength value#))
-         ))
-     ([segment offset value]
-      `(let [segment# ~segment
+     ([segment n value]
+      `(let [n# ~n
+             segment# ~segment
+             value# ~(with-meta value {:tag 'floats})]
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfFloat float-layout 0 n#)))
+     ([segment n offset value]
+      `(let [n# ~n
+             segment# ~segment
              offset# ~offset
-             value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfFloat float-layout ^long offset# ^{:tag 'int} (alength value#))
-         ))
-     ([segment offset byte-order value]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order
-             value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# (.withOrder ^ValueLayout$OfFloat float-layout ^ByteOrder byte-order#) ^long offset# ^{:tag 'int} (alength value#)))))}
-  ([^MemorySegment segment ^floats value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfFloat float-layout 0 ^int (alength value)))
-  ([^MemorySegment segment ^long offset ^floats value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfFloat float-layout ^long offset ^int (alength value)))
-  ([^MemorySegment segment ^long offset ^ByteOrder byte-order ^floats value]
-   (MemorySegment/copy value 0 segment (.withOrder ^ValueLayout$OfFloat float-layout byte-order) ^long offset ^int (alength value))))
+             value# ~(with-meta value {:tag 'floats})]
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfFloat float-layout ^long offset# n#))))}
+  ([^MemorySegment segment n ^floats value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfFloat float-layout 0 ^int n))
+  ([^MemorySegment segment n ^long offset ^floats value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfFloat float-layout ^long offset ^int n)))
 
 (defn write-doubles
-  "Writes a [[double]] array to the `segment`, at an optional `offset`.
+  "Writes n elements from a [[double]] array to the `segment`, at an optional `offset`.
 
   If `byte-order` is not provided, it defaults to [[native-endian]]."
   {:inline
    (fn write-doubles-inline
-     ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfDouble double-layout 0 ^{:tag 'int} (alength value#))
-         ))
-     ([segment offset value]
-      `(let [segment# ~segment
+     ([segment n value]
+      `(let [n# ~n
+             segment# ~segment
+             value# ~(with-meta value {:tag 'doubles})]
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfDouble double-layout 0 n#)))
+     ([segment n offset value]
+      `(let [n# ~n
+             segment# ~segment
              offset# ~offset
-             value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfDouble double-layout ^long offset# ^{:tag 'int} (alength value#))
-         ))
-     ([segment offset byte-order value]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order
-             value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# (.withOrder ^ValueLayout$OfDouble double-layout ^ByteOrder byte-order#) ^long offset# ^{:tag 'int} (alength value#)))))}
-  ([^MemorySegment segment ^doubles value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfDouble double-layout 0 ^int (alength value)))
-  ([^MemorySegment segment ^long offset ^doubles value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfDouble double-layout ^long offset ^int (alength value)))
-  ([^MemorySegment segment ^long offset ^ByteOrder byte-order ^doubles value]
-   (MemorySegment/copy value 0 segment (.withOrder ^ValueLayout$OfDouble double-layout byte-order) ^long offset ^int (alength value))))
+             value# ~(with-meta value {:tag 'doubles})]
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfDouble double-layout ^long offset# n#))))}
+  ([^MemorySegment segment n ^doubles value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfDouble double-layout 0 ^int n))
+  ([^MemorySegment segment n ^long offset ^doubles value]
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfDouble double-layout ^long offset ^int n)))
 
 (defn- type-dispatch
   "Gets a type dispatch value from a (potentially composite) type."
@@ -1665,12 +1630,14 @@
 
 (defmethod generate-serialize :coffi.mem/array   [[_arr member-type length & {:keys [raw?]}] source-form offset segment-source-form]
   (if (and raw? (coffitype->array-write-fn member-type))
-    (list (coffitype->array-write-fn member-type) segment-source-form offset source-form)
-    (let [obj (gensym 'src-array)]
-      (concat
-       (list `let [obj source-form])
-       (map #(generate-serialize member-type (list (if raw? `aget `nth) obj %) (+ offset (* (size-of member-type) %)) segment-source-form)
-       (range length))))))
+    (list (coffitype->array-write-fn member-type) segment-source-form length offset source-form)
+    (if (coffitype->array-write-fn member-type)
+      (list (coffitype->array-write-fn member-type) segment-source-form length offset (list (coffitype->array-fn member-type) length source-form))
+      (let [obj (gensym 'src-array)]
+       (concat
+        (list `let [obj source-form])
+        (map #(generate-serialize member-type (list (if raw? `aget `nth) obj %) (+ offset (* (size-of member-type) %)) segment-source-form)
+             (range length)))))))
 
 (defn register-new-struct-serialization [typename [_struct fields]]
   (let [typelist (typelist typename fields)

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -35,7 +35,8 @@
     ValueLayout$OfDouble)
    (java.lang.ref Cleaner)
    (java.util.function Consumer)
-   (java.nio ByteOrder)))
+   (java.nio ByteOrder))
+  (:refer-clojure :exclude [defstruct]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1811,7 +1811,8 @@
 (defmethod generate-deserialize :coffi.mem/float    [_type offset segment-source-form] `(read-float   ~segment-source-form ~offset))
 (defmethod generate-deserialize :coffi.mem/double   [_type offset segment-source-form] `(read-double  ~segment-source-form ~offset))
 (defmethod generate-deserialize :coffi.mem/pointer  [_type offset segment-source-form] `(read-address ~segment-source-form ~offset))
-(defmethod generate-deserialize :coffi.mem/c-string [_type offset segment-source-form] (list `.getString (list `.reinterpret (list `.get (with-meta segment-source-form {:tag 'java.lang.foreign.MemorySegment}) `pointer-layout offset) `Integer/MAX_VALUE) 0))
+(defmethod generate-deserialize :coffi.mem/c-string [_type offset segment-source-form]
+  `(.getString (.reinterpret (.get ~(with-meta segment-source-form {:tag 'java.lang.foreign.MemorySegment}) pointer-layout ~offset) Integer/MAX_VALUE) 0))
 
 (defn- generate-deserialize-array-as-array-bulk [array-type n offset segment-source-form]
   (list (coffitype->array-read-fn array-type) segment-source-form n offset))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1634,7 +1634,7 @@
               (range n))
              [(if raw? gen-arr (list `vec gen-arr))])]))
 
-(defn typelist [typename fields]
+(defn- typelist [typename fields]
   (->>
    (partition 2 2 (interleave (reductions + 0 (map (comp size-of second) fields)) fields))
    (filter (fn [[_ [_ field-type]]] (not (and (vector? field-type) (= ::padding (first field-type))))))))
@@ -1927,7 +1927,11 @@
 (defmacro defstruct
   "Defines a struct type. all members need to be supplied in pairs of `coffi-type member-name`.
 
-  This creates needed serialization and deserialization implementations for the new type."
+  This creates needed serialization and deserialization implementations for the new type.
+
+  The typenames have to be coffi typenames, such as `:coffi.mem/int` or `[:coffi.mem/array :coffi.mem/byte 3]`.
+  Arrays are wrapped with vectors by default. If you want to use raw java arrays the array type has to be supplied with the option `:raw? true`, for example like this `[:coffi.mem/array :coffi.mem/byte 3 :raw? true]`
+  "
   {:style/indent [:defn]}
   [typename members]
   (let [invalid-typenames (filter #(try (c-layout (first %)) nil (catch Exception e (first %))) (partition 2 members))]

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1634,7 +1634,7 @@
 (defmethod generate-deserialize :coffi.mem/float    [_type offset] [`(read-float   ~'segment ~offset)])
 (defmethod generate-deserialize :coffi.mem/double   [_type offset] [`(read-double  ~'segment ~offset)])
 (defmethod generate-deserialize :coffi.mem/pointer  [_type offset] [`(read-address ~'segment ~offset)])
-(defmethod generate-deserialize :coffi.mem/c-string [_type offset] [(list `.getString (list `.reinterpret (with-meta 'segment {:tag 'java.lang.foreign.MemorySegment}) `Integer/MAX_VALUE) 0)])
+(defmethod generate-deserialize :coffi.mem/c-string [_type offset] [(list `.getString (list `.reinterpret (list `.get (with-meta 'segment {:tag 'java.lang.foreign.MemorySegment}) `pointer-layout offset) `Integer/MAX_VALUE) 0)])
 
 (defmethod generate-deserialize :coffi.mem/array    [_type offset]
   (let [outer-code `(let [arr# (~(coffitype->array-fn (second _type)) ~(second (rest _type)))] arr# )

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1916,24 +1916,14 @@
             (vec-methods   [] [(vec-length) (vec-assoc) (vec-assocN) (vec-peek) (vec-pop) (vec-nth) (vec-nth-2) (vec-cons) (vec-equiv) (vec-empty) (vec-iterator) (vec-foreach) (vec-seq) (vec-rseq)])
             (struct-methods [] [(s-count) (s-containsKey) (s-valAt) (s-valAt-2) (s-entryAt)])
             (prefix-methods [prefix ms] (map (fn [[method-name & tail]] (cons (with-meta (symbol (str prefix method-name)) (meta method-name)) tail)) ms))
-            (impl-methods [] (concat (prefix-methods "map_" (map-methods)) (prefix-methods "vec_" (vec-methods)) (prefix-methods "struct_" (struct-methods))))
-            ]
-      (if maplike?
-        (concat
-         [`deftype (symbol (name typename)) (vec typed-member-symbols) `coffi.mem.IStruct `coffi.mem.IStructImpl `clojure.lang.IPersistentMap `clojure.lang.MapEquivalence `java.util.Map]
-         (struct-methods)
-         (map-methods)
-         (impl-methods)
-         [(list 'asMap ['this] 'this)
-          (list 'asVec ['this] (list `VecWrap. 'this))])
-        (concat
-         [`deftype (symbol (name typename)) (vec typed-member-symbols) `coffi.mem.IStruct `clojure.lang.IPersistentVector]
-         (struct-methods)
-         (vec-methods)
-         [(list 'asMap ['this]
-                (list `proxy [`coffi.mem.IStruct `clojure.lang.IPersistentVector] []
-                      (concat (struct-methods) (map-methods) [(list 'asMap ['newthis] 'this) (list 'asVec ['newthis] 'newthis)] )))
-          (list 'asVec ['this] 'this)])))))
+            (impl-methods [] (concat (prefix-methods "map_" (map-methods)) (prefix-methods "vec_" (vec-methods)) (prefix-methods "struct_" (struct-methods))))]
+      (concat
+       [`deftype (symbol (name typename)) (vec typed-member-symbols) `coffi.mem.IStruct `coffi.mem.IStructImpl `clojure.lang.IPersistentMap `clojure.lang.MapEquivalence `java.util.Map]
+       (struct-methods)
+       (map-methods)
+       (impl-methods)
+       [(list 'asMap ['this] 'this)
+        (list 'asVec ['this] (list `VecWrap. 'this))]))))
 
 (defmacro defstruct
   "Defines a struct type. all members need to be supplied in pairs of `coffi-type member-name`.

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -689,13 +689,13 @@
       `(let [segment# ~segment
              offset# ~offset
              value# ~value]
-         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfShort short-layout ^long offset ^int (alength value#))))
+         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfShort short-layout ^long offset# ^int (alength value#))))
      ([segment offset byte-order value]
       `(let [segment# ~segment
              offset# ~offset
              byte-order# ~byte-order
              value# ~value]
-         (MemorySegment/copy value# 0 segment# (.withOrder ^ValueLayout$OfShort short-layout ^ByteOrder byte-order#) ^long offset ^int (alength value#)))))}
+         (MemorySegment/copy value# 0 segment# (.withOrder ^ValueLayout$OfShort short-layout ^ByteOrder byte-order#) ^long offset# ^int (alength value#)))))}
   ([^MemorySegment segment ^shorts value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfShort short-layout 0 (alength value)))
   ([^MemorySegment segment ^long offset ^shorts value]
@@ -712,20 +712,20 @@
      ([segment value]
       `(let [segment# ~segment
              value# ~value]
-         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfInt int-layout 0 ^int (alength value#))
+         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfInt int-layout 0 ^{:tag 'int} (alength value#))
          ))
      ([segment offset value]
       `(let [segment# ~segment
              offset# ~offset
              value# ~value]
-         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfInt int-layout ^long offset ^int (alength value#))
+         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfInt int-layout ^long offset# ^{:tag 'int} (alength value#))
          ))
      ([segment offset byte-order value]
       `(let [segment# ~segment
              offset# ~offset
              byte-order# ~byte-order
              value# ~value]
-         (MemorySegment/copy value# 0 segment# (.withOrder ^ValueLayout$OfInt int-layout ^ByteOrder byte-order#) ^long offset ^int (alength value#)))))}
+         (MemorySegment/copy value# 0 segment# (.withOrder ^ValueLayout$OfInt int-layout ^ByteOrder byte-order#) ^long offset# ^{:tag 'int} (alength value#)))))}
   ([^MemorySegment segment ^ints value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfInt int-layout 0 (alength value)))
   ([^MemorySegment segment ^long offset ^ints value]
@@ -742,20 +742,20 @@
      ([segment value]
       `(let [segment# ~segment
              value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfLong long-layout 0 ^int (alength value#))
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfLong long-layout 0 ^{:tag 'int} (alength value#))
          ))
      ([segment offset value]
       `(let [segment# ~segment
              offset# ~offset
              value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfLong long-layout ^long offset ^int (alength value#))
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfLong long-layout ^long offset# ^{:tag 'int} (alength value#))
          ))
      ([segment offset byte-order value]
       `(let [segment# ~segment
              offset# ~offset
              byte-order# ~byte-order
              value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# (.withOrder ^ValueLayout$OfLong long-layout ^ByteOrder byte-order#) ^long offset ^int (alength value#)))))}
+         (MemorySegment/copy value# 0 ^MemorySegment segment# (.withOrder ^ValueLayout$OfLong long-layout ^ByteOrder byte-order#) ^long offset# ^{:tag 'int} (alength value#)))))}
   ([^MemorySegment segment ^longs value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfLong long-layout 0 ^int (alength value)))
   ([^MemorySegment segment ^long offset ^longs value]
@@ -773,18 +773,18 @@
      ([segment value]
       `(let [segment# ~segment
              value# ~value]
-         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# ^ValueLayout$OfChar char-layout 0 ^int (alength value#))))
+         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# ^ValueLayout$OfChar char-layout 0 ^{:tag 'int} (alength value#))))
      ([segment offset value]
       `(let [segment# ~segment
              offset# ~offset
              value# ~value]
-         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# ^ValueLayout$OfChar char-layout ^long offset ^int (alength value#))))
+         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# ^ValueLayout$OfChar char-layout ^long offset# ^{:tag 'int} (alength value#))))
      ([segment offset byte-order value]
       `(let [segment# ~segment
              offset# ~offset
              byte-order# ~byte-order
              value# ~value]
-         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# (.withOrder ^ValueLayout$OfChar char-layout ^ByteOrder byte-order#) ^long offset ^int (alength value#)))))}
+         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# (.withOrder ^ValueLayout$OfChar char-layout ^ByteOrder byte-order#) ^long offset# ^{:tag 'int} (alength value#)))))}
   ([^MemorySegment segment ^chars value]
    (MemorySegment/copy (bytes (byte-array (map unchecked-int value))) 0 segment ^ValueLayout$OfChar char-layout 0 (alength value)))
   ([^MemorySegment segment ^long offset ^chars value]
@@ -801,20 +801,20 @@
      ([segment value]
       `(let [segment# ~segment
              value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfFloat float-layout 0 ^int (alength value#))
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfFloat float-layout 0 ^{:tag 'int} (alength value#))
          ))
      ([segment offset value]
       `(let [segment# ~segment
              offset# ~offset
              value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfFloat float-layout ^long offset ^int (alength value#))
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfFloat float-layout ^long offset# ^{:tag 'int} (alength value#))
          ))
      ([segment offset byte-order value]
       `(let [segment# ~segment
              offset# ~offset
              byte-order# ~byte-order
              value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# (.withOrder ^ValueLayout$OfFloat float-layout ^ByteOrder byte-order#) ^long offset ^int (alength value#)))))}
+         (MemorySegment/copy value# 0 ^MemorySegment segment# (.withOrder ^ValueLayout$OfFloat float-layout ^ByteOrder byte-order#) ^long offset# ^{:tag 'int} (alength value#)))))}
   ([^MemorySegment segment ^floats value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfFloat float-layout 0 ^int (alength value)))
   ([^MemorySegment segment ^long offset ^floats value]
@@ -831,20 +831,20 @@
      ([segment value]
       `(let [segment# ~segment
              value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfDouble double-layout 0 ^int (alength value#))
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfDouble double-layout 0 ^{:tag 'int} (alength value#))
          ))
      ([segment offset value]
       `(let [segment# ~segment
              offset# ~offset
              value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfDouble double-layout ^long offset ^int (alength value#))
+         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfDouble double-layout ^long offset# ^{:tag 'int} (alength value#))
          ))
      ([segment offset byte-order value]
       `(let [segment# ~segment
              offset# ~offset
              byte-order# ~byte-order
              value# ~value]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# (.withOrder ^ValueLayout$OfDouble double-layout ^ByteOrder byte-order#) ^long offset ^int (alength value#)))))}
+         (MemorySegment/copy value# 0 ^MemorySegment segment# (.withOrder ^ValueLayout$OfDouble double-layout ^ByteOrder byte-order#) ^long offset# ^{:tag 'int} (alength value#)))))}
   ([^MemorySegment segment ^doubles value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfDouble double-layout 0 ^int (alength value)))
   ([^MemorySegment segment ^long offset ^doubles value]
@@ -1607,6 +1607,15 @@
    _type
    `object-array))
 
+(defn- coffitype->array-write-fn [_type]
+  ({:coffi.mem/byte   `write-bytes
+    :coffi.mem/short  `write-shorts
+    :coffi.mem/int    `write-ints
+    :coffi.mem/long   `write-longs
+    :coffi.mem/char   `write-chars
+    :coffi.mem/float  `write-floats
+    :coffi.mem/double `write-doubles} _type))
+
 (defmulti  generate-deserialize (fn [& xs] (if (vector? (first xs)) (first (first xs)) (first xs))))
 
 (defmethod generate-deserialize :coffi.mem/byte     [_type offset segment-source-form] `(read-byte    ~segment-source-form ~offset))
@@ -1655,12 +1664,13 @@
 (defmethod generate-serialize :coffi.mem/c-string [_type source-form offset segment-source-form] `(write-address ~segment-source-form ~offset (.allocateFrom (Arena/ofAuto) ~source-form)))
 
 (defmethod generate-serialize :coffi.mem/array   [[_arr member-type length & {:keys [raw?]}] source-form offset segment-source-form]
-  (let [obj (gensym 'src-array)]
-    (concat
-     (list `let [obj source-form])
-     (map
-      #(generate-serialize member-type (list (if raw? `aget `nth) obj %) (+ offset (* (size-of member-type) %)) segment-source-form)
-     (range length)))))
+  (if (and raw? (coffitype->array-write-fn member-type))
+    (list (coffitype->array-write-fn member-type) segment-source-form offset source-form)
+    (let [obj (gensym 'src-array)]
+      (concat
+       (list `let [obj source-form])
+       (map #(generate-serialize member-type (list (if raw? `aget `nth) obj %) (+ offset (* (size-of member-type) %)) segment-source-form)
+       (range length))))))
 
 (defn register-new-struct-serialization [typename [_struct fields]]
   (let [typelist (typelist typename fields)

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1876,7 +1876,7 @@
 
             (s-count       [] (list 'count       ['this]           (count members)))
             (s-assoc       [] (list 'assoc       ['this 'i 'value] (list `if (list `number? 'i) (list `assoc as-vec 'i 'value) (assoc as-map 'i 'value))))
-            (s-containsKey [] (list 'containsKey ['this 'k]        (list `if (list `number? 'k) (list `and (list `>= 'k 0) (list `< 'k (count members))) (list (set members) 'k))))
+            (s-containsKey [] (list 'containsKey ['this 'k]        (list `if (list `number? 'k) (list `and (list `>= 'k 0) (list `< 'k (count members)) true) (list `case 'k (seq members) true false))))
             (s-valAt       [] (list 'valAt       ['this 'k]        (concat [`case 'k] (interleave (range) as-vec) (interleave members as-vec))))
             (s-valAt-2     [] (list 'valAt       ['this 'k 'o]     (concat [`case 'k] (interleave (range) as-vec) (interleave members as-vec) ['o])))
             (s-entryAt     [] (list 'entryAt     ['this 'k]        (list `clojure.lang.MapEntry/create 'k (concat [`case 'k] (interleave (range) as-vec) (interleave members as-vec)))))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1650,20 +1650,19 @@
   (let [outer-code `(let [arr# (~(coffitype->array-fn (second _type)) ~(second (rest _type)))] arr# )
         gen-arr (nth outer-code 2)]
     [(concat (butlast outer-code)
-             (list
-              (concat [`aset gen-arr]
-                      (reduce
-                       concat
-                       (map
-                        (fn [index]
-                          (let [deserialize-instructions
-                                (generate-deserialize
-                                 (second _type)
-                                 (+ offset (* (size-of (second _type)) index)))]
-                            (if (vector? deserialize-instructions)
-                              (list index (first deserialize-instructions))
-                              (list index deserialize-instructions))))
-                        (range (second (rest _type)))))))
+             (map
+              (fn [index]
+                (let [deserialize-instructions
+                      (generate-deserialize
+                       (second _type)
+                       (+ offset (* (size-of (second _type)) index)))]
+                  (list `aset gen-arr index (first deserialize-instructions))
+                  #_(if true #_(vector? deserialize-instructions)
+                        (list index (first deserialize-instructions))
+                        (list index deserialize-instructions))
+
+                  ))
+              (range (second (rest _type))))
              [gen-arr])]))
 
 (defn typelist [typename fields]

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -2170,7 +2170,7 @@
          (~'asMap [~'this] ~'this)
          (~'asVec [~'this] (VecWrap. ~'this))))))
 
-(load-file "src/clj/coffi/layout.clj")
+(load "layout")
 
 (defmacro defstruct
   "Defines a struct type. all members need to be supplied in pairs of `member-name coffi-type`.

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1769,7 +1769,7 @@
                       ::c-string 'String}]
     (cond (and arr? raw?) (get array-types type 'objects)
           (and arr?)      `clojure.lang.IPersistentVector
-          :default        (get single-types type (keyword (str *ns*) (str type))))))
+          :default        (get single-types type type))))
 
 (defn- coffitype->array-fn [type]
   (get

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1938,6 +1938,7 @@
                                            (map #(update % 1 keyword))
                                            (map reverse)
                                            (map vec))])]
+        (if (resolve typename) (ns-unmap *ns* typename))
         (register-new-struct-deserialization coffi-typename struct-layout)
         (register-new-struct-serialization   coffi-typename struct-layout)
         `(do

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1885,7 +1885,7 @@
             (map-assoc     [] (list 'assoc       ['this 'i 'value] (list `assoc as-map 'i 'value)))
             (map-assocEx   [] (list 'assocEx     ['this 'i 'value] (list `if (list (set members) 'i) (list `throw (list `Exception. "key already exists")) (assoc as-map 'i 'value))))
             (map-without   [] (list 'without     ['this 'k]        (list `dissoc as-map (list `if (list `number? 'k) (list (vec members) 'k) 'k))))
-            (map-cons      [] (list 'cons        ['this 'o]        `(if (instance? clojure.lang.MapEntry ~'o) ~(conj as-map [`(.getKey ^clojure.lang.MapEntry ~'o) `(.getKey ^clojure.lang.MapEntry ~'o)]) (if (instance? clojure.lang.IPersistentVector ~'o) ~(conj as-map [`(.nth ^IPersistentVector ~'o 0) `(.nth ^IPersistentVector ~'o 1)]) (.cons ^IPersistentMap ~'o ~as-map)))))
+            (map-cons      [] (list 'cons        ['this 'o]        `(if (instance? clojure.lang.MapEntry ~'o) ~(conj as-map [`(.key ~(with-meta 'o {:tag 'clojure.lang.MapEntry})) `(.val ~(with-meta 'o {:tag 'clojure.lang.MapEntry}))]) (if (instance? clojure.lang.IPersistentVector ~'o) ~(conj as-map [`(.nth ~(with-meta 'o {:tag 'clojure.lang.IPersistentVector}) 0) `(.nth ~(with-meta 'o {:tag 'clojure.lang.IPersistentVector}) 1)]) (.cons ~(with-meta 'o {:tag 'clojure.lang.IPersistentMap}) ~as-map)))))
             (map-equiv     [] (list 'equiv       ['this 'o]        (list `= as-map 'o)))
             (map-empty     [] (list 'empty       ['this]           {}))
             (map-iterator  [] (list 'iterator    ['this]           (list '.iterator as-map)))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -2185,16 +2185,22 @@
             (struct-methods [] [(s-count) (s-containsKey) (s-valAt) (s-valAt-2) (s-entryAt)])
             (prefix-methods [prefix ms] (map (fn [[method-name & tail]] (cons (with-meta (symbol (str prefix method-name)) (meta method-name)) tail)) ms))
             (impl-methods [] (concat (prefix-methods "map_" (map-methods)) (prefix-methods "vec_" (vec-methods)) (prefix-methods "struct_" (struct-methods))))]
-      (concat
-       [`deftype (symbol (name typename)) (vec typed-member-symbols) `coffi.mem.IStruct `coffi.mem.IStructImpl `clojure.lang.IPersistentMap `clojure.lang.MapEquivalence `java.util.Map `clojure.lang.IFn]
-       (struct-methods)
-       (map-methods)
-       (impl-methods)
-       [(s-nth-key)
-        (invoke1)
-        (invoke2)
-        (list 'asMap ['this] 'this)
-        (list 'asVec ['this] (list `VecWrap. 'this))]))))
+      `(deftype ~(symbol (name typename)) ~(vec typed-member-symbols)
+         coffi.mem.IStruct
+         ~@(struct-methods)
+         coffi.mem.IStructImpl
+         ~@(impl-methods)
+         clojure.lang.IPersistentMap
+         clojure.lang.MapEquivalence
+         java.util.Map
+         ~@(map-methods)
+         clojure.lang.IFn
+         ~(s-nth-key)
+         ~(invoke1)
+         ~(invoke2)
+
+         (~'asMap [~'this] ~'this)
+         (~'asVec [~'this] (VecWrap. ~'this)))
 
 (defmacro defstruct
   "Defines a struct type. all members need to be supplied in pairs of `coffi-type member-name`.

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -817,6 +817,278 @@
   ([^MemorySegment segment n ^long offset ^doubles value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfDouble double-layout ^long offset ^int n)))
 
+
+
+
+
+
+
+(defn read-bytes
+  "reads `n` elements from a `segment` to a [[byte]] array, at an optional `offset`."
+  {:inline
+   (fn read-bytes-inline
+     ([segment n]
+      `(let [n# ~n
+             segment# ~segment
+             arr# (byte-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfByte byte-layout 0 arr# 0 n#)
+         arr#))
+     ([segment n offset]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             arr# (byte-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfByte byte-layout offset# arr# 0 n#)
+         arr#))
+     ([segment n offset byte-order]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             byte-order# ~byte-order
+             arr# (byte-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# (.withOrder ^ValueLayout$OfByte byte-layout ^ByteOrder byte-order#) offset# arr# 0 n#)
+         arr#)))}
+  ([^MemorySegment segment n]
+   (let [arr (byte-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfByte byte-layout 0 arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset]
+   (let [arr (byte-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfByte byte-layout offset arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset ^ByteOrder byte-order]
+   (let [arr (byte-array n)]
+     (MemorySegment/copy segment (.withOrder ^ValueLayout$OfByte byte-layout byte-order) offset arr 0 ^int n)
+     arr)))
+
+(defn read-shorts
+  "reads `n` elements from a `segment` to a [[short]] array, at an optional `offset`."
+  {:inline
+   (fn read-shorts-inline
+     ([segment n]
+      `(let [n# ~n
+             segment# ~segment
+             arr# (short-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfShort short-layout 0 arr# 0 n#)
+         arr#))
+     ([segment n offset]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             arr# (short-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfShort short-layout offset# arr# 0 n#)
+         arr#))
+     ([segment n offset byte-order]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             byte-order# ~byte-order
+             arr# (short-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# (.withOrder ^ValueLayout$OfShort short-layout ^ByteOrder byte-order#) offset# arr# 0 n#)
+         arr#)))}
+  ([^MemorySegment segment n]
+   (let [arr (short-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfShort short-layout 0 arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset]
+   (let [arr (short-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfShort short-layout offset arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset ^ByteOrder byte-order]
+   (let [arr (short-array n)]
+     (MemorySegment/copy segment (.withOrder ^ValueLayout$OfShort short-layout byte-order) offset arr 0 ^int n)
+     arr)))
+
+(defn read-longs
+  "reads `n` elements from a `segment` to a [[long]] array, at an optional `offset`."
+  {:inline
+   (fn read-longs-inline
+     ([segment n]
+      `(let [n# ~n
+             segment# ~segment
+             arr# (long-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfLong long-layout 0 arr# 0 n#)
+         arr#))
+     ([segment n offset]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             arr# (long-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfLong long-layout offset# arr# 0 n#)
+         arr#))
+     ([segment n offset byte-order]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             byte-order# ~byte-order
+             arr# (long-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# (.withOrder ^ValueLayout$OfLong long-layout ^ByteOrder byte-order#) offset# arr# 0 n#)
+         arr#)))}
+  ([^MemorySegment segment n]
+   (let [arr (long-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfLong long-layout 0 arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset]
+   (let [arr (long-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfLong long-layout offset arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset ^ByteOrder byte-order]
+   (let [arr (long-array n)]
+     (MemorySegment/copy segment (.withOrder ^ValueLayout$OfLong long-layout byte-order) offset arr 0 ^int n)
+     arr)))
+
+(defn read-ints
+  "reads `n` elements from a `segment` to a [[int]] array, at an optional `offset`."
+  {:inline
+   (fn read-ints-inline
+     ([segment n]
+      `(let [n# ~n
+             segment# ~segment
+             arr# (int-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfInt int-layout 0 arr# 0 n#)
+         arr#))
+     ([segment n offset]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             arr# (int-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfInt int-layout offset# arr# 0 n#)
+         arr#))
+     ([segment n offset byte-order]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             byte-order# ~byte-order
+             arr# (int-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# (.withOrder ^ValueLayout$OfInt int-layout ^ByteOrder byte-order#) offset# arr# 0 n#)
+         arr#)))}
+  ([^MemorySegment segment n]
+   (let [arr (int-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfInt int-layout 0 arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset]
+   (let [arr (int-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfInt int-layout offset arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset ^ByteOrder byte-order]
+   (let [arr (int-array n)]
+     (MemorySegment/copy segment (.withOrder ^ValueLayout$OfInt int-layout byte-order) offset arr 0 ^int n)
+     arr)))
+
+(defn read-chars
+  "reads `n` elements from a `segment` to a [[char]] array, at an optional `offset`."
+  {:inline
+   (fn read-chars-inline
+     ([segment n]
+      `(let [n# ~n
+             segment# ~segment
+             arr# (char-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfChar char-layout 0 arr# 0 n#)
+         arr#))
+     ([segment n offset]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             arr# (char-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfChar char-layout offset# arr# 0 n#)
+         arr#))
+     ([segment n offset byte-order]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             byte-order# ~byte-order
+             arr# (char-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# (.withOrder ^ValueLayout$OfChar char-layout ^ByteOrder byte-order#) offset# arr# 0 n#)
+         arr#)))}
+  ([^MemorySegment segment n]
+   (let [arr (char-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfChar char-layout 0 arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset]
+   (let [arr (char-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfChar char-layout offset arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset ^ByteOrder byte-order]
+   (let [arr (char-array n)]
+     (MemorySegment/copy segment (.withOrder ^ValueLayout$OfChar char-layout byte-order) offset arr 0 ^int n)
+     arr)))
+
+(defn read-floats
+  "reads `n` elements from a `segment` to a [[float]] array, at an optional `offset`."
+  {:inline
+   (fn read-floats-inline
+     ([segment n]
+      `(let [n# ~n
+             segment# ~segment
+             arr# (float-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfFloat float-layout 0 arr# 0 n#)
+         arr#))
+     ([segment n offset]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             arr# (float-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfFloat float-layout offset# arr# 0 n#)
+         arr#))
+     ([segment n offset byte-order]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             byte-order# ~byte-order
+             arr# (float-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# (.withOrder ^ValueLayout$OfFloat float-layout ^ByteOrder byte-order#) offset# arr# 0 n#)
+         arr#)))}
+  ([^MemorySegment segment n]
+   (let [arr (float-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfFloat float-layout 0 arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset]
+   (let [arr (float-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfFloat float-layout offset arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset ^ByteOrder byte-order]
+   (let [arr (float-array n)]
+     (MemorySegment/copy segment (.withOrder ^ValueLayout$OfFloat float-layout byte-order) offset arr 0 ^int n)
+     arr)))
+
+(defn read-doubles
+  "reads `n` elements from a `segment` to a [[double]] array, at an optional `offset`."
+  {:inline
+   (fn read-doubles-inline
+     ([segment n]
+      `(let [n# ~n
+             segment# ~segment
+             arr# (double-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfDouble double-layout 0 arr# 0 n#)
+         arr#))
+     ([segment n offset]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             arr# (double-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# ^ValueLayout$OfDouble double-layout offset# arr# 0 n#)
+         arr#))
+     ([segment n offset byte-order]
+      `(let [n# ~n
+             segment# ~segment
+             offset# ~offset
+             byte-order# ~byte-order
+             arr# (double-array ~n)]
+         (MemorySegment/copy ^MemorySegment segment# (.withOrder ^ValueLayout$OfDouble double-layout ^ByteOrder byte-order#) offset# arr# 0 n#)
+         arr#)))}
+  ([^MemorySegment segment n]
+   (let [arr (double-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfDouble double-layout 0 arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset]
+   (let [arr (double-array n)]
+     (MemorySegment/copy segment ^ValueLayout$OfDouble double-layout offset arr 0 ^int n)
+     arr))
+  ([^MemorySegment segment n ^long offset ^ByteOrder byte-order]
+   (let [arr (double-array n)]
+     (MemorySegment/copy segment (.withOrder ^ValueLayout$OfDouble double-layout byte-order) offset arr 0 ^int n)
+     arr)))
+
 (defn- type-dispatch
   "Gets a type dispatch value from a (potentially composite) type."
   [type]
@@ -1581,6 +1853,15 @@
     :coffi.mem/float  `write-floats
     :coffi.mem/double `write-doubles} _type))
 
+(defn- coffitype->array-read-fn [_type]
+  ({:coffi.mem/byte   `read-bytes
+    :coffi.mem/short  `read-shorts
+    :coffi.mem/int    `read-ints
+    :coffi.mem/long   `read-longs
+    :coffi.mem/char   `read-chars
+    :coffi.mem/float  `read-floats
+    :coffi.mem/double `read-doubles} _type))
+
 (defmulti  generate-deserialize (fn [& xs] (if (vector? (first xs)) (first (first xs)) (first xs))))
 
 (defmethod generate-deserialize :coffi.mem/byte     [_type offset segment-source-form] `(read-byte    ~segment-source-form ~offset))
@@ -1594,13 +1875,18 @@
 (defmethod generate-deserialize :coffi.mem/c-string [_type offset segment-source-form] (list `.getString (list `.reinterpret (list `.get (with-meta segment-source-form {:tag 'java.lang.foreign.MemorySegment}) `pointer-layout offset) `Integer/MAX_VALUE) 0))
 
 (defmethod generate-deserialize :coffi.mem/array    [[_ array-type n & {:keys [raw?]}] offset segment-source-form]
-  (let [a (gensym 'array)]
-    (concat
-     `(let [~a (~(coffitype->array-fn array-type) ~n)])
-     (map
-      #(list `aset a % (generate-deserialize array-type (+ offset (* (size-of array-type) %)) segment-source-form))
-      (range n))
-     [(if raw? a `(vec ~a))])))
+  (if (coffitype->array-read-fn array-type)
+    (if raw?
+      (list (coffitype->array-read-fn array-type) segment-source-form n offset)
+      (list `vec (list (coffitype->array-read-fn array-type) segment-source-form n offset)))
+
+      (let [a (gensym 'array)]
+        (concat
+         `(let [~a (~(coffitype->array-fn array-type) ~n)])
+         (map
+          #(list `aset a % (generate-deserialize array-type (+ offset (* (size-of array-type) %)) segment-source-form))
+          (range n))
+         [(if raw? a `(vec ~a))]))))
 
 (defn- typelist [typename fields]
   (->>

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1801,7 +1801,7 @@
     :coffi.mem/float  `read-floats
     :coffi.mem/double `read-doubles} type))
 
-(defmulti  generate-deserialize (fn [& xs] (if (vector? (first xs)) (first (first xs)) (first xs))))
+(defmulti  generate-deserialize (fn [& xs] (if (vector? (first xs)) (ffirst xs) (first xs))))
 
 (defmethod generate-deserialize :coffi.mem/byte     [_type offset segment-source-form] `(read-byte    ~segment-source-form ~offset))
 (defmethod generate-deserialize :coffi.mem/short    [_type offset segment-source-form] `(read-short   ~segment-source-form ~offset))
@@ -1879,7 +1879,7 @@
               (generate-deserialize field-type (+ global-offset offset) segment-source-form)))
            (cons (symbol (str (name typename) ".")))))))
 
-(defmulti  generate-serialize (fn [& xs] (if (vector? (first xs)) (first (first xs)) (first xs))))
+(defmulti  generate-serialize (fn [& xs] (if (vector? (first xs)) (ffirst xs) (first xs))))
 
 (defmethod generate-serialize :coffi.mem/byte     [_type source-form offset segment-source-form] `(write-byte    ~segment-source-form ~offset ~source-form))
 (defmethod generate-serialize :coffi.mem/short    [_type source-form offset segment-source-form] `(write-short   ~segment-source-form ~offset ~source-form))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1857,7 +1857,7 @@
 (defn as-map [^coffi.mem.IStruct struct] (.asMap struct))
 
 
-(defn- generate-struct-type [typename typed-member-symbols maplike?]
+(defn- generate-struct-type [typename typed-member-symbols]
   (let [members (map (comp keyword str) typed-member-symbols)
         as-vec (vec (map (comp symbol name) members))
         as-map (into {} (map (fn [m] [m (symbol (name m))]) members))]
@@ -1958,7 +1958,7 @@
         (register-new-struct-deserialization coffi-typename struct-layout)
         (register-new-struct-serialization   coffi-typename struct-layout)
         `(do
-           ~(generate-struct-type typename typed-symbols true)
+           ~(generate-struct-type typename typed-symbols)
            (defmethod c-layout ~coffi-typename [~'_] (c-layout ~struct-layout))
            (defmethod deserialize-from ~coffi-typename ~[segment-form '_type]
              ~(generate-deserialize coffi-typename 0 segment-form))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1846,8 +1846,6 @@
     :coffi.mem/float  `read-floats
     :coffi.mem/double `read-doubles} _type))
 
-(def array-copy-method :bulk)
-
 (defmulti  generate-deserialize (fn [& xs] (if (vector? (first xs)) (first (first xs)) (first xs))))
 
 (defmethod generate-deserialize :coffi.mem/byte     [_type offset segment-source-form] `(read-byte    ~segment-source-form ~offset))
@@ -2001,7 +1999,7 @@
       (->> typelist
            (map-indexed
             (fn [index [offset [_ field-type]]]
-              (generate-serialize field-type (list (symbol (str "." (name (nth fieldnames index)))) 'source-obj) (if (number? global-offset) (+ global-offset offset) `(+ ~global-offset ~offset)) segment-source-form)))
+              (generate-serialize field-type (list (symbol (str "." (name (nth fieldnames index)))) 'source-obj) (if (number? global-offset) (+ global-offset offset) `(unchecked-add-int ~global-offset ~offset)) segment-source-form)))
            (concat [`let ['source-obj source-form]])))))
 
 (gen-interface

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -2021,7 +2021,7 @@
 (for-each-fixed-length 15)
 (for-each-fixed-length 16)
 
-(deftype struct-vec-iterator [^coffi.mem.IStructImpl struct-obj ^int size ^{:volatile-mutable true :tag int} i]
+(deftype StructVecIterator [^coffi.mem.IStructImpl struct-obj ^int size ^{:volatile-mutable true :tag int} i]
   java.util.Iterator
   (forEachRemaining [this action]
     (case (- size i)
@@ -2145,7 +2145,7 @@
             (vec-cons      [] (list 'cons        ['this 'o]        (vec (cons 'o as-vec))))
             (vec-equiv     [] (list 'equiv       ['this 'o]        (list `= as-vec 'o)))
             (vec-empty     [] (list 'empty       ['this]           []))
-            (vec-iterator  [] (list 'iterator    ['this]           (list `struct-vec-iterator. 'this (count members) 0)))
+            (vec-iterator  [] (list 'iterator    ['this]           (list `StructVecIterator. 'this (count members) 0)))
             (vec-foreach   [] (concat ['forEach  ['this 'action]]  (partition 2 (interleave (repeat 'action) as-vec))))
             (vec-seq       [] (list 'seq         ['this]           (list `StructVecSeq. 'this 0)))
             (vec-rseq      [] (list 'rseq        ['this]           (list `seq (vec (reverse as-vec)))))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -479,7 +479,7 @@
      ([segment offset value]
       `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
                         offset ~offset long
-                        value ~value int]
+                        value ~value byte]
          (.set segment ^ValueLayout$OfByte byte-layout offset value))))}
   ([^MemorySegment segment value]
    (.set segment ^ValueLayout$OfByte byte-layout 0 ^byte value))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1750,7 +1750,7 @@
     (assoc struct-spec 1 aligned-fields)))
 
 (defn- coffitype->typename [in]
-  (let [[arr _type n & {:keys [raw?] :as opts}] (if (vector? in) in [:- in])
+  (let [[arr type n & {:keys [raw?] :as opts}] (if (vector? in) in [:- in])
         arr? (= arr ::array)
         array-types  {::byte   'bytes
                       ::short  'shorts
@@ -1767,11 +1767,11 @@
                       ::float    'float
                       ::double   'double
                       ::c-string 'String}]
-    (cond (and arr? raw?) (get array-types _type 'objects)
+    (cond (and arr? raw?) (get array-types type 'objects)
           (and arr?)      `clojure.lang.IPersistentVector
-          :default        (get single-types _type (keyword (str *ns*) (str _type))))))
+          :default        (get single-types type (keyword (str *ns*) (str type))))))
 
-(defn- coffitype->array-fn [_type]
+(defn- coffitype->array-fn [type]
   (get
    {:coffi.mem/byte   `byte-array
     :coffi.mem/short  `short-array
@@ -1780,26 +1780,26 @@
     :coffi.mem/char   `char-array
     :coffi.mem/float  `float-array
     :coffi.mem/double `double-array}
-   _type
+   type
    `object-array))
 
-(defn- coffitype->array-write-fn [_type]
+(defn- coffitype->array-write-fn [type]
   ({:coffi.mem/byte   `write-bytes
     :coffi.mem/short  `write-shorts
     :coffi.mem/int    `write-ints
     :coffi.mem/long   `write-longs
     :coffi.mem/char   `write-chars
     :coffi.mem/float  `write-floats
-    :coffi.mem/double `write-doubles} _type))
+    :coffi.mem/double `write-doubles} type))
 
-(defn- coffitype->array-read-fn [_type]
+(defn- coffitype->array-read-fn [type]
   ({:coffi.mem/byte   `read-bytes
     :coffi.mem/short  `read-shorts
     :coffi.mem/int    `read-ints
     :coffi.mem/long   `read-longs
     :coffi.mem/char   `read-chars
     :coffi.mem/float  `read-floats
-    :coffi.mem/double `read-doubles} _type))
+    :coffi.mem/double `read-doubles} type))
 
 (defmulti  generate-deserialize (fn [& xs] (if (vector? (first xs)) (first (first xs)) (first xs))))
 
@@ -2214,7 +2214,7 @@
             typed-symbols (->>
                            members
                            (partition 2 2)
-                           (map (fn [[_type sym]] (with-meta sym {:tag (coffitype->typename _type)})))
+                           (map (fn [[type sym]] (with-meta sym {:tag (coffitype->typename type)})))
                            (vec))
             struct-layout-raw [::struct
                                (->>

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1846,7 +1846,7 @@
     (->> (typelist fields)
          (map-indexed
           (fn [index [offset [_ field-type]]]
-            (generate-deserialize field-type (+ global-offset offset) segment-source-form)))
+            (generate-deserialize field-type (if (number? global-offset) (+ global-offset offset) `(+ ~global-offset ~offset)) segment-source-form)))
          (cons (symbol (str (name typename) "."))))))
 
 (defmulti  generate-serialize (fn [& xs] (if (vector? (first xs)) (ffirst xs) (first xs))))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -284,6 +284,17 @@
   "The alignment in bytes of a c-sized pointer."
   (.byteAlignment pointer-layout))
 
+(defmacro with-typehints [bindings form]
+  (let [bindmap (->> bindings
+                     (partition 3)
+                     (map (fn [[sym src hint]] [sym (with-meta (gensym (str (name sym))) {:src-expr src :tag (symbol (str (name hint)))})]))
+                     (into (hash-map)))
+        letbinds (->> bindmap
+                      (map (fn [[_ newsym]] [(with-meta newsym {}) (:src-expr (meta newsym))]))
+                      (reduce concat)
+                      (vec))]
+    `(let ~letbinds ~(clojure.walk/postwalk (fn [x] (get bindmap x x)) form))))
+
 (defn read-byte
   "Reads a [[byte]] from the `segment`, at an optional `offset`."
   {:inline
@@ -462,14 +473,14 @@
   {:inline
    (fn write-byte-inline
      ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfByte byte-layout 0 value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value byte]
+         (.set segment ^ValueLayout$OfByte byte-layout 0 value)))
      ([segment offset value]
-      `(let [segment# ~segment
-             offset# ~offset
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfByte byte-layout offset# value#))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value int]
+         (.set segment ^ValueLayout$OfByte byte-layout offset value))))}
   ([^MemorySegment segment value]
    (.set segment ^ValueLayout$OfByte byte-layout 0 ^byte value))
   ([^MemorySegment segment ^long offset value]
@@ -482,20 +493,20 @@
   {:inline
    (fn write-short-inline
      ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfShort short-layout 0 value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value short]
+         (.set segment ^ValueLayout$OfShort short-layout 0 value)))
      ([segment offset value]
-      `(let [segment# ~segment
-             offset# ~offset
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfShort short-layout offset# value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value short]
+         (.set segment ^ValueLayout$OfShort short-layout offset value)))
      ([segment offset byte-order value]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order
-             value# ~value]
-         (.set ^MemorySegment segment# (.withOrder ^ValueLayout$OfShort short-layout ^ByteOrder byte-order#) offset# value#))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        byte-order ~byte-order java.nio.ByteOrder
+                        value ~value short]
+         (.set segment (.withOrder ^ValueLayout$OfShort short-layout byte-order) offset value))))}
   ([^MemorySegment segment value]
    (.set segment ^ValueLayout$OfShort short-layout 0 ^short value))
   ([^MemorySegment segment ^long offset value]
@@ -510,20 +521,20 @@
   {:inline
    (fn write-int-inline
      ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfInt int-layout 0 value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value int]
+         (.set segment ^ValueLayout$OfInt int-layout 0 value)))
      ([segment offset value]
-      `(let [segment# ~segment
-             offset# ~offset
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfInt int-layout offset# value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value int]
+         (.set segment ^ValueLayout$OfInt int-layout offset value)))
      ([segment offset byte-order value]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order
-             value# ~value]
-         (.set ^MemorySegment segment# (.withOrder ^ValueLayout$OfInt int-layout ^ByteOrder byte-order#) offset# value#))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        byte-order ~byte-order java.nio.ByteOrder
+                        value ~value int]
+         (.set segment (.withOrder ^ValueLayout$OfInt int-layout byte-order) offset value))))}
   ([^MemorySegment segment value]
    (.set segment ^ValueLayout$OfInt int-layout 0 ^int value))
   ([^MemorySegment segment ^long offset value]
@@ -538,20 +549,20 @@
   {:inline
    (fn write-long-inline
      ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfLong long-layout 0 value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value long]
+         (.set segment ^ValueLayout$OfLong long-layout 0 value)))
      ([segment offset value]
-      `(let [segment# ~segment
-             offset# ~offset
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfLong long-layout offset# value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value long]
+         (.set segment ^ValueLayout$OfLong long-layout offset value)))
      ([segment offset byte-order value]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order
-             value# ~value]
-         (.set ^MemorySegment segment# (.withOrder ^ValueLayout$OfLong long-layout ^ByteOrder byte-order#) offset# value#))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        byte-order ~byte-order java.nio.ByteOrder
+                        value ~value long]
+         (.set segment (.withOrder ^ValueLayout$OfLong long-layout byte-order) offset value))))}
   (^long [^MemorySegment segment ^long value]
    (.set segment ^ValueLayout$OfLong long-layout 0 value))
   (^long [^MemorySegment segment ^long offset ^long value]
@@ -564,14 +575,14 @@
   {:inline
    (fn write-char-inline
      ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfByte byte-layout 0 (unchecked-byte (unchecked-int value#)))))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value char]
+         (.set segment ^ValueLayout$OfByte byte-layout 0 (unchecked-byte (unchecked-int value)))))
      ([segment offset value]
-      `(let [segment# ~segment
-             offset# ~offset
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfByte byte-layout offset# (unchecked-byte (unchecked-int value#))))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value char]
+         (.set segment ^ValueLayout$OfByte byte-layout offset (unchecked-byte (unchecked-int value))))))}
   ([^MemorySegment segment value]
    (.set
     segment
@@ -590,20 +601,20 @@
   {:inline
    (fn write-float-inline
      ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfFloat float-layout 0 value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value float]
+         (.set segment ^ValueLayout$OfFloat float-layout 0 value)))
      ([segment offset value]
-      `(let [segment# ~segment
-             offset# ~offset
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfFloat float-layout offset# value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value float]
+         (.set segment ^ValueLayout$OfFloat float-layout offset value)))
      ([segment offset byte-order value]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order
-             value# ~value]
-         (.set ^MemorySegment segment# (.withOrder ^ValueLayout$OfFloat float-layout ^ByteOrder byte-order#) offset# value#))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        byte-order ~byte-order java.nio.ByteOrder
+                        value ~value float]
+         (.set segment (.withOrder ^ValueLayout$OfFloat float-layout byte-order) offset value))))}
   ([^MemorySegment segment value]
    (.set segment ^ValueLayout$OfFloat float-layout 0 ^float value))
   ([^MemorySegment segment ^long offset value]
@@ -618,20 +629,20 @@
   {:inline
    (fn write-double-inline
      ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfDouble double-layout 0 value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value double]
+         (.set segment ^ValueLayout$OfDouble double-layout 0 value)))
      ([segment offset value]
-      `(let [segment# ~segment
-             offset# ~offset
-             value# ~value]
-         (.set ^MemorySegment segment# ^ValueLayout$OfDouble double-layout offset# value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value double]
+         (.set segment ^ValueLayout$OfDouble double-layout offset value)))
      ([segment offset byte-order value]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order
-             value# ~value]
-         (.set ^MemorySegment segment# (.withOrder ^ValueLayout$OfDouble double-layout ^ByteOrder byte-order#) offset# value#))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        byte-order ~byte-order java.nio.ByteOrder
+                        value ~value double]
+         (.set segment (.withOrder ^ValueLayout$OfDouble double-layout byte-order) offset value))))}
   (^double [^MemorySegment segment ^double value]
    (.set segment ^ValueLayout$OfDouble double-layout 0 value))
   (^double [^MemorySegment segment ^long offset ^double value]
@@ -644,14 +655,14 @@
   {:inline
    (fn write-address-inline
      ([segment value]
-      `(let [segment# ~segment
-             value# ~value]
-         (.set ^MemorySegment segment# ^AddressLayout pointer-layout 0 ^MemorySegment value#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value java.lang.foreign.MemorySegment]
+         (.set segment ^AddressLayout pointer-layout 0 value)))
      ([segment offset value]
-      `(let [segment# ~segment
-             offset# ~offset
-             value# ~value]
-         (.set ^MemorySegment segment# ^AddressLayout pointer-layout offset# ^MemorySegment value#))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value java.lang.foreign.MemorySegment]
+         (.set segment ^AddressLayout pointer-layout offset value))))}
   ([^MemorySegment segment ^MemorySegment value]
    (.set segment ^AddressLayout pointer-layout 0 value))
   ([^MemorySegment segment ^long offset ^MemorySegment value]
@@ -660,18 +671,16 @@
 (defn write-bytes
   "Writes n elements from a [[byte]] array to the `segment`, at an optional `offset`."
   {:inline
-   (fn write-byte-inline
+   (fn write-bytes-inline
      ([segment n value]
-      `(let [n# ~n
-             segment# ~segment
-             value# ~(with-meta value {:tag 'bytes})]
-         (MemorySegment/copy value# 0  ^MemorySegment segment# ^ValueLayout$OfByte byte-layout 0 n#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value bytes]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfByte byte-layout 0 ~n)))
      ([segment n offset value]
-      `(let [n# ~n
-             segment# ~segment
-             offset# ~offset
-             value# ~(with-meta value {:tag 'bytes})]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfByte byte-layout offset# n#))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value bytes]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfByte byte-layout offset ~n))))}
   ([^MemorySegment segment n ^bytes value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfByte byte-layout 0 ^int n))
   ([^MemorySegment segment n offset ^bytes value]
@@ -684,16 +693,14 @@
   {:inline
    (fn write-shorts-inline
      ([segment n value]
-      `(let [n# ~n
-             segment# ~segment
-             value# ~(with-meta value {:tag 'shorts})]
-         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfShort short-layout 0 n#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value shorts]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfShort short-layout 0 ~n)))
      ([segment n offset value]
-      `(let [n# ~n
-             segment# ~segment
-             offset# ~offset
-             value# ~(with-meta value {:tag 'shorts})]
-         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfShort short-layout ^long offset# n#))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value shorts]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfShort short-layout offset ~n))))}
   ([^MemorySegment segment n ^shorts value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfShort short-layout 0 ^int n))
   ([^MemorySegment segment n ^long offset ^shorts value]
@@ -706,22 +713,18 @@
   {:inline
    (fn write-ints-inline
      ([segment n value]
-      `(let [n# ~n
-             segment# ~segment
-             value# ~(with-meta value {:tag 'shorts})]
-         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfInt int-layout 0 n#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value ints]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfInt int-layout 0 ~n)))
      ([segment n offset value]
-      `(let [n# ~n
-             segment# ~segment
-             offset# ~offset
-             value# ~(with-meta value {:tag 'shorts})]
-         (MemorySegment/copy value# 0 segment# ^ValueLayout$OfInt int-layout ^long offset# n#)))
-     )}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value ints]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfInt int-layout offset ~n))))}
   ([^MemorySegment segment n ^ints value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfInt int-layout 0 ^int n))
   ([^MemorySegment segment n ^long offset ^ints value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfInt int-layout ^long offset ^int n))
-  )
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfInt int-layout ^long offset ^int n)))
 
 (defn write-longs
   "Writes n elements from a [[long]] array to the `segment`, at an optional `offset`.
@@ -730,25 +733,18 @@
   {:inline
    (fn write-longs-inline
      ([segment n value]
-      `(let [n# ~n
-             segment# ~segment
-             value# ~(with-meta value {:tag 'longs})]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfLong long-layout 0 n#)
-         ))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value longs]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfLong long-layout 0 ~n)))
      ([segment n offset value]
-      `(let [n# ~n
-             segment# ~segment
-             offset# ~offset
-             value# ~(with-meta value {:tag 'longs})]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfLong long-layout ^long offset# n#)
-         ))
-     )}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value longs]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfLong long-layout offset ~n))))}
   ([^MemorySegment segment n ^longs value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfLong long-layout 0 ^int n))
   ([^MemorySegment segment n ^long offset ^longs value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfLong long-layout ^long offset ^int n))
-  )
-
+   (MemorySegment/copy value 0 segment ^ValueLayout$OfLong long-layout ^long offset ^int n)))
 
 (defn write-chars
   "Writes n elements from a [[char]] array to the `segment`, at an optional `offset`.
@@ -757,17 +753,14 @@
   {:inline
    (fn write-chars-inline
      ([segment n value]
-      `(let [n# ~n
-             segment# ~segment
-             value# ~(with-meta value {:tag 'chars})]
-         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# ^ValueLayout$OfChar char-layout 0 n#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value chars]
+         (MemorySegment/copy (bytes (byte-array (map unchecked-int value))) 0 segment ^ValueLayout$OfChar char-layout 0 ~n)))
      ([segment n offset value]
-      `(let [n# ~n
-             segment# ~segment
-             offset# ~offset
-             value# ~(with-meta value {:tag 'chars})]
-         (MemorySegment/copy (bytes (byte-array (map unchecked-int value#))) 0 segment# ^ValueLayout$OfChar char-layout ^long offset# n#)))
-     )}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value chars]
+         (MemorySegment/copy (bytes (byte-array (map unchecked-int value))) 0 segment ^ValueLayout$OfChar char-layout offset ~n))))}
   ([^MemorySegment segment n ^chars value]
    (MemorySegment/copy (bytes (byte-array (map unchecked-int value))) 0 segment ^ValueLayout$OfChar char-layout 0 ^int n))
   ([^MemorySegment segment n ^long offset ^chars value]
@@ -780,16 +773,14 @@
   {:inline
    (fn write-floats-inline
      ([segment n value]
-      `(let [n# ~n
-             segment# ~segment
-             value# ~(with-meta value {:tag 'floats})]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfFloat float-layout 0 n#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value floats]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfFloat float-layout 0 ~n)))
      ([segment n offset value]
-      `(let [n# ~n
-             segment# ~segment
-             offset# ~offset
-             value# ~(with-meta value {:tag 'floats})]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfFloat float-layout ^long offset# n#))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value floats]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfFloat float-layout offset ~n))))}
   ([^MemorySegment segment n ^floats value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfFloat float-layout 0 ^int n))
   ([^MemorySegment segment n ^long offset ^floats value]
@@ -802,25 +793,18 @@
   {:inline
    (fn write-doubles-inline
      ([segment n value]
-      `(let [n# ~n
-             segment# ~segment
-             value# ~(with-meta value {:tag 'doubles})]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfDouble double-layout 0 n#)))
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        value ~value doubles]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfDouble double-layout 0 ~n)))
      ([segment n offset value]
-      `(let [n# ~n
-             segment# ~segment
-             offset# ~offset
-             value# ~(with-meta value {:tag 'doubles})]
-         (MemorySegment/copy value# 0 ^MemorySegment segment# ^ValueLayout$OfDouble double-layout ^long offset# n#))))}
+      `(with-typehints [segment ~segment java.lang.foreign.MemorySegment
+                        offset ~offset long
+                        value ~value doubles]
+         (MemorySegment/copy value 0 segment ^ValueLayout$OfDouble double-layout offset ~n))))}
   ([^MemorySegment segment n ^doubles value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfDouble double-layout 0 ^int n))
   ([^MemorySegment segment n ^long offset ^doubles value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfDouble double-layout ^long offset ^int n)))
-
-
-
-
-
 
 
 (defn read-bytes

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1880,7 +1880,7 @@
             (s-containsKey [] (list 'containsKey ['this 'k]        (list `if (list `number? 'k) (list `and (list `>= 'k 0) (list `< 'k (count members)) true) (list `case 'k (seq members) true false))))
             (s-valAt       [] (list 'valAt       ['this 'k]        (concat [`case 'k] (interleave (range) as-vec) (interleave members as-vec))))
             (s-valAt-2     [] (list 'valAt       ['this 'k 'o]     (concat [`case 'k] (interleave (range) as-vec) (interleave members as-vec) ['o])))
-            (s-entryAt     [] (list 'entryAt     ['this 'k]        (list `clojure.lang.MapEntry/create 'k (concat [`case 'k] (interleave (range) as-vec) (interleave members as-vec)))))
+            (s-entryAt     [] (list 'entryAt     ['this 'k]        (list `let ['val-or-nil (concat [`case 'k] (interleave (range) as-vec) (interleave members as-vec) [nil])] (list `if 'val-or-nil (list `clojure.lang.MapEntry/create 'val-or-nil nil)))))
 
             (map-assoc       [] (list 'assoc       ['this 'i 'value] (list `assoc as-map 'i 'value)))
             (map-assocEx   [] (list 'assocEx     ['this 'i 'value] (list `if (list (set members) 'i) (list `throw (list `Exception. "key already exists")) (assoc as-map 'i 'value))))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1883,7 +1883,7 @@
 
             (map-assocEx   [] (list 'assocEx     ['this 'i 'value] (list `if (list (set members) 'i) (list `throw (list `Exception. "key already exists")) (assoc as-map 'i 'value))))
             (map-without   [] (list 'without     ['this 'k]        (list `dissoc as-map (list `if (list `number? 'k) (list (vec members) 'k) 'k))))
-            (map-cons      [] (list 'cons        ['this 'o]        (vec (cons 'o as-map))))
+            (map-cons      [] (list 'cons        ['this 'o]        `(if (instance? clojure.lang.MapEntry ~'o) ~(conj as-map [`(.getKey ^clojure.lang.MapEntry ~'o) `(.getKey ^clojure.lang.MapEntry ~'o)]) (if (instance? clojure.lang.IPersistentVector ~'o) ~(conj as-map [`(.nth ^IPersistentVector ~'o 0) `(.nth ^IPersistentVector ~'o 1)]) (.cons ^IPersistentMap ~'o ~as-map)))))
             (map-equiv     [] (list 'equiv       ['this 'o]        (list `= as-map 'o)))
             (map-empty     [] (list 'empty       ['this]           {}))
             (map-iterator  [] (list 'iterator    ['this]           (list '.iterator as-map)))
@@ -1949,9 +1949,6 @@
            (defmethod serialize-into ~coffi-typename ~[(with-meta 'source-obj {:tag typename}) '_type 'segment '_]
              ~(generate-serialize coffi-typename (with-meta 'source-obj {:tag typename}) 0))
            (defmethod clojure.pprint/simple-dispatch ~typename [~'obj] (clojure.pprint/simple-dispatch (into {} ~'obj)))
-           (defmethod clojure.core/print-method ~typename [~'obj ~'writer] (print-simple (into {} ~'obj) ~'writer))
-           )
-        )
-      ))
-  )
+           (defmethod clojure.core/print-method ~typename [~'obj ~'writer] (print-simple (into {} ~'obj) ~'writer)))))))
+
 

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -2200,7 +2200,7 @@
          ~(invoke2)
 
          (~'asMap [~'this] ~'this)
-         (~'asVec [~'this] (VecWrap. ~'this)))
+         (~'asVec [~'this] (VecWrap. ~'this))))))
 
 (defmacro defstruct
   "Defines a struct type. all members need to be supplied in pairs of `coffi-type member-name`.

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1922,7 +1922,7 @@
   (let [invalid-typenames (filter #(try (c-layout (first %)) nil (catch Exception e (first %))) (partition 2 members))]
     (cond
       (odd? (count members)) (throw (Exception. "uneven amount of members supplied. members have to be typed and are required to be supplied in the form of `typename member-name`. the typename has to be coffi typename, like `:coffi.mem/int` or `[:coffi.mem/array :coffi.mem/byte 3]`"))
-      (seq invalid-typenames) (throw (Exception. (str "invalid typename/s " (print-str invalid-typenames) ". typename has to be coffi typename, like `:coffi.mem/int` or `[:coffi.mem/array :coffi.mem/byte 3]`")))
+      (seq invalid-typenames) (throw (Exception. (str "invalid typename/s " (print-str invalid-typenames) ". typename has to be coffi typename, like `:coffi.mem/int` or `[:coffi.mem/array :coffi.mem/byte 3]`. The type/s you referenced also might not be defined. In case of a custom type, ensure that you use the correctly namespaced keyword to refer to it.")))
       :else
       (let [coffi-typename (keyword (str *ns*) (str typename))
             typed-symbols (->>

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1842,9 +1842,6 @@
         (generate-deserialize-array-as-array-inline array-type n offset segment-source-form)
         (generate-deserialize-array-as-array-loop array-type n offset segment-source-form)))))
 
-(defn- generate-deserialize-array-as-vector-bulk [array-type n offset segment-source-form]
-  (list `vec (list (coffitype->array-read-fn array-type) segment-source-form n offset)))
-
 (defn- generate-deserialize-array-as-vector-loop [array-type n offset segment-source-form]
   (let [loop-deserialize (generate-deserialize array-type `(+ ~offset (* ~(size-of array-type) ~'i)) segment-source-form)]
     `(loop [~'i 0 ~'v (transient [])]

--- a/test/c/ffi_test.c
+++ b/test/c/ffi_test.c
@@ -78,3 +78,25 @@ void test_call_with_trailing_string_arg(int a, int b, char* text) {
     return;
 }
 
+typedef struct complextype {
+    Point x;
+    char  y;
+    int   z[4];
+    char *w;
+} ComplexType;
+
+ComplexType complexTypeTest(ComplexType a) {
+  ComplexType ret = {};
+  ret.x = a.x;
+  ret.x.x++;
+  ret.x.y++;
+  ret.y = a.y-1;
+  ret.z[0] = a.z[0];
+  ret.z[1] = a.z[1];
+  ret.z[2] = a.z[2];
+  ret.z[3] = a.z[3];
+  ret.w = "hello from c";
+  return ret;
+}
+
+

--- a/test/clj/coffi/ffi_test.clj
+++ b/test/clj/coffi/ffi_test.clj
@@ -70,3 +70,29 @@
            (catch Throwable _t
              :err))
       :ok)))
+
+
+(mem/defstruct Point [::mem/float x ::mem/float y])
+
+(t/deftest can-call-with-defstruct
+  (t/is (= {:x 2.0 :y 2.0}
+           ((ffi/cfn "add_points" [::Point ::Point] ::Point) (Point. 1 2) (Point. 1 0)))))
+
+(mem/defstruct AlignmentTest [::mem/char a ::mem/double x ::mem/float y])
+
+(t/deftest padding-matches-defstruct
+  (t/is (= ((ffi/cfn "get_struct" [] ::AlignmentTest))
+           {:a \x
+            :x 3.14
+            :y 42.0})))
+
+(mem/defstruct ComplexType [::Point x ::mem/byte y [::mem/array ::mem/int 4] z ::mem/c-string w])
+
+(t/deftest can-call-with-complex-defstruct
+  (t/are [x y] (= x (y ((ffi/cfn "complexTypeTest" [::ComplexType] ::ComplexType)
+                        (ComplexType. (Point. 2 3) 4 (int-array [5 6 7 8]) "hello from clojure"))))
+    {:x {:x 3.0 :y 4.0} :y 3 :w "hello from c"} #(dissoc % :z)
+    [5 6 7 8] (comp vec :z)))
+
+
+

--- a/test/clj/coffi/ffi_test.clj
+++ b/test/clj/coffi/ffi_test.clj
@@ -95,5 +95,13 @@
     {:x {:x 3.0 :y 4.0} :y 3 :w "hello from c"} #(dissoc % :z)
     [5 6 7 8] (comp vec :z)))
 
+(mem/defstruct ComplexTypeWrapped [::Point x ::mem/byte y [::mem/array ::mem/int 4] z ::mem/c-string w] :raw-arrays? false)
+
+(t/deftest can-call-with-wrapped-complex-defstruct
+  (t/are [x y] (= x (y ((ffi/cfn "complexTypeTest" [::ComplexTypeWrapped] ::ComplexTypeWrapped)
+                        (ComplexTypeWrapped. (Point. 2 3) 4 (int-array [5 6 7 8]) "hello from clojure"))))
+    {:x {:x 3.0 :y 4.0} :y 3 :w "hello from c"} #(dissoc % :z)
+    [5 6 7 8] (comp vec :z)))
+
 
 

--- a/test/clj/coffi/ffi_test.clj
+++ b/test/clj/coffi/ffi_test.clj
@@ -3,7 +3,8 @@
    [clojure.test :as t]
    [coffi.ffi :as ffi]
    [coffi.layout :as layout]
-   [coffi.mem :as mem]))
+   [coffi.mem :as mem]
+   [clojure.pprint]))
 
 (ffi/load-library "target/ffi_test.so")
 

--- a/test/clj/coffi/ffi_test.clj
+++ b/test/clj/coffi/ffi_test.clj
@@ -87,7 +87,7 @@
             :x 3.14
             :y 42.0})))
 
-(mem/defstruct ComplexType [::Point x ::mem/byte y [::mem/array ::mem/int 4] z ::mem/c-string w])
+(mem/defstruct ComplexType [::Point x ::mem/byte y [::mem/array ::mem/int 4 :raw? true] z ::mem/c-string w])
 
 (t/deftest can-call-with-complex-defstruct
   (t/are [x y] (= x (y ((ffi/cfn "complexTypeTest" [::ComplexType] ::ComplexType)
@@ -95,7 +95,7 @@
     {:x {:x 3.0 :y 4.0} :y 3 :w "hello from c"} #(dissoc % :z)
     [5 6 7 8] (comp vec :z)))
 
-(mem/defstruct ComplexTypeWrapped [::Point x ::mem/byte y [::mem/array ::mem/int 4] z ::mem/c-string w] :raw-arrays? false)
+(mem/defstruct ComplexTypeWrapped [::Point x ::mem/byte y [::mem/array ::mem/int 4] z ::mem/c-string w])
 
 (t/deftest can-call-with-wrapped-complex-defstruct
   (t/are [x y] (= x (y ((ffi/cfn "complexTypeTest" [::ComplexTypeWrapped] ::ComplexTypeWrapped)

--- a/test/clj/coffi/ffi_test.clj
+++ b/test/clj/coffi/ffi_test.clj
@@ -73,13 +73,13 @@
       :ok)))
 
 
-(mem/defstruct Point [::mem/float x ::mem/float y])
+(mem/defstruct Point [x ::mem/float y ::mem/float])
 
 (t/deftest can-call-with-defstruct
   (t/is (= {:x 2.0 :y 2.0}
            ((ffi/cfn "add_points" [::Point ::Point] ::Point) (Point. 1 2) (Point. 1 0)))))
 
-(mem/defstruct AlignmentTest [::mem/char a ::mem/double x ::mem/float y])
+(mem/defstruct AlignmentTest [a ::mem/char x ::mem/double y ::mem/float])
 
 (t/deftest padding-matches-defstruct
   (t/is (= ((ffi/cfn "get_struct" [] ::AlignmentTest))
@@ -87,7 +87,7 @@
             :x 3.14
             :y 42.0})))
 
-(mem/defstruct ComplexType [::Point x ::mem/byte y [::mem/array ::mem/int 4 :raw? true] z ::mem/c-string w])
+(mem/defstruct ComplexType [x ::Point y ::mem/byte z [::mem/array ::mem/int 4 :raw? true] w ::mem/c-string])
 
 (t/deftest can-call-with-complex-defstruct
   (t/are [x y] (= x (y ((ffi/cfn "complexTypeTest" [::ComplexType] ::ComplexType)
@@ -95,13 +95,11 @@
     {:x {:x 3.0 :y 4.0} :y 3 :w "hello from c"} #(dissoc % :z)
     [5 6 7 8] (comp vec :z)))
 
-(mem/defstruct ComplexTypeWrapped [::Point x ::mem/byte y [::mem/array ::mem/int 4] z ::mem/c-string w])
+(mem/defstruct ComplexTypeWrapped [x ::Point y ::mem/byte z [::mem/array ::mem/int 4] w ::mem/c-string])
 
 (t/deftest can-call-with-wrapped-complex-defstruct
   (t/are [x y] (= x (y ((ffi/cfn "complexTypeTest" [::ComplexTypeWrapped] ::ComplexTypeWrapped)
                         (ComplexTypeWrapped. (Point. 2 3) 4 (int-array [5 6 7 8]) "hello from clojure"))))
     {:x {:x 3.0 :y 4.0} :y 3 :w "hello from c"} #(dissoc % :z)
     [5 6 7 8] (comp vec :z)))
-
-
 

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -40,32 +40,34 @@
   (t/is (TestType. 5 10 15)))
 
 (t/deftest can-use-common-map-functions
-  (t/are [x y] (= x (y (TestType. 5 10 15)))
-    5  :a
-    10 :b
-    15 :c
-    5  #(% :a)
-    10 #(% :b)
-    15 #(% :c)
-    5  #(get :a)
-    10 #(get :b)
-    15 #(get :c)
-    20 #(get :d 20)
-    nil #(get :d)
-    [:a :b :c] keys
-    [5 10 15]  vals
-    {:a 5 :c 15} #(dissoc % :b)
-    {:a 5 :b 10 :c 0} #(assoc % :c 0)
-    {:a 5 :b 10 :c 15 :d 20} #(assoc % :d 20)
-    [[:a 5] [:b 10] [:c 15]] seq
-    {:a 5 :b 10 :c 15 :d 20} #(merge % {:d 20})
-    {:a [5 6] :b [10 11] :c [15 16]} #(merge-with vector % {:a 6 :b 11 :c 16})
-    {:a [5 6] :b [10 11] :c [15 16]} #(merge-with vector % (TestType. 6 11 16))
-    [:a 5] #(find % :a)
-    nil #(find % :d)
-    {:a 5 :b 10 :c 15} identity
-    (TestType. 5 10 15) identity
-    (TestType. 5 10 15) (fn [s] {:a 5 :b 10 :c 15})))
+  (let [v1 (TestType. 5 10 15)
+        v2 (TestType. 6 11 16)]
+    (t/are [x y] (= x (y v1))
+     5  :a
+     10 :b
+     15 :c
+     5  (fn [v] (v :a))
+     10 (fn [v] (v :b))
+     15 (fn [v] (v :c))
+     5  #(get % :a)
+     10 #(get % :b)
+     15 #(get % :c)
+     20 #(get % :d 20)
+     nil #(get % :d)
+     [:a :b :c] keys
+     [5 10 15]  vals
+     {:a 5 :c 15} #(dissoc % :b)
+     {:a 5 :b 10 :c 0} #(assoc % :c 0)
+     {:a 5 :b 10 :c 15 :d 20} #(assoc % :d 20)
+     [[:a 5] [:b 10] [:c 15]] seq
+     {:a 5 :b 10 :c 15 :d 20} #(merge % {:d 20})
+     {:a [5 6] :b [10 11] :c [15 16]} #(merge-with vector % {:a 6 :b 11 :c 16})
+     {:a [5 6] :b [10 11] :c [15 16]} #(merge-with vector % v2)
+     [:a 5] #(find % :a)
+     nil #(find % :d)
+     {:a 5 :b 10 :c 15} identity
+     v1 identity
+     v1 (fn [s] {:a 5 :b 10 :c 15}))))
 
 (t/deftest can-serialize-struct-type
   (t/is
@@ -80,6 +82,8 @@
   (t/is
    (eval
     `(mem/defstruct ~'NestedTestType [::mem/int ~'x ::mem/byte ~'y ::TestType ~'z]))))
+
+(mem/defstruct NestedTestType [::mem/int x ::mem/byte y ::TestType z])
 
 (t/deftest can-instantiated-nested-structs
   (t/is

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -76,7 +76,6 @@
    (= {:a 5 :b 10 :c 15}
       (mem/deserialize (mem/serialize (TestType. 5 10 15) ::TestType) ::TestType))))
 
-
 (t/deftest can-define-nested-structs
   (t/is
    (eval
@@ -92,9 +91,39 @@
    (eval
     `(mem/defstruct ~'ArrayTestType [::mem/int ~'x ::mem/byte ~'y [::mem/array ::mem/int 4] ~'z]))))
 
+(mem/defstruct ArrayTestType [::mem/int x ::mem/byte y [::mem/array ::mem/int 4] z])
+
 (t/deftest can-instantiated-array-member-structs
   (t/are [x y z] (z x (y (ArrayTestType. 5 6 (int-array [1 2 3 4]))))
-      {:x 5 :y 6} #(dissoc % :z) =
-      (int-array [1 2 3 4]) :z java.util.Arrays/equals))
+    {:x 5 :y 6} #(dissoc % :z) =
+    (int-array [1 2 3 4]) :z java.util.Arrays/equals))
 
+(t/deftest can-serialize-array-struct
+  (t/is
+   (= [5 6 1 2 3 4]
+      (vec (filter #(not= 0 %) (vec (.toArray (mem/serialize (ArrayTestType. 5 6 (int-array [1 2 3 4])) ::ArrayTestType) mem/byte-layout)))))))
+
+(t/deftest can-serialize-deserialize-array-struct
+  (t/is
+   (java.util.Arrays/equals
+    (int-array [1 2 3 4])
+    (.z (mem/deserialize (mem/serialize (ArrayTestType. 5 6 (int-array [1 2 3 4])) ::ArrayTestType) ::ArrayTestType)))))
+
+(t/deftest can-define-complex-structs
+  (t/is
+   (eval
+    `(mem/defstruct ~'ComplexTestType [[::mem/array ::ArrayTestType 4] ~'x ::mem/byte ~'y [::mem/array ::mem/int 4] ~'z ::NestedTestType ~'w]))))
+
+(mem/defstruct ComplexTestType [[::mem/array ::ArrayTestType 4] x ::mem/byte y [::mem/array ::mem/int 4] z ::NestedTestType w])
+
+(t/deftest can-serialize-deserialize-complex-struct-type
+  (t/is
+   (let [x (object-array (map #(ArrayTestType. % % (int-array (range 4))) (range 4)))
+         y 12
+         z (int-array (range 4))
+         w (NestedTestType. 5 6 (TestType. 5 10 15))]
+     (->
+      (ComplexTestType. x y z w)
+      (mem/serialize ::ComplexTestType)
+      (mem/deserialize ::ComplexTestType)))))
 

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -29,4 +29,39 @@
   (t/is
    (instance? MemorySegment (mem/serialize "this is a string" ::mem/c-string))))
 
+(t/deftest can-define-struct
+  (t/is
+   (eval
+    `(mem/defstruct ~'TestType [::mem/int ~'a ::mem/byte ~'b]))))
+
+(mem/defstruct TestType [::mem/int a ::mem/byte b ::mem/short c])
+
+(t/deftest can-initialize-struct
+  (t/is (TestType. 5 10 15)))
+
+(t/deftest can-use-common-map-functions
+  (t/are [x y] (= x (y (TestType. 5 10 15)))
+    5  :a
+    10 :b
+    15 :c
+    5  #(% :a)
+    10 #(% :b)
+    15 #(% :c)
+    5  #(get :a)
+    10 #(get :b)
+    15 #(get :c)
+    20 #(get :d 20)
+    nil #(get :d)
+    [:a :b :c] keys
+    [5 10 15]  vals
+    {:a 5 :c 15} #(dissoc % :b)
+    {:a 5 :b 10 :c 0} #(assoc % :c 0)
+    {:a 5 :b 10 :c 15 :d 20} #(assoc % :d 20)
+    [[:a 5] [:b 10] [:c 15]] seq
+    {:a 5 :b 10 :c 15 :d 20} #(merge % {:d 20})
+    {:a [5 6] :b [10 11] :c [15 16]} #(merge-with vector % {:a 6 :b 11 :c 16})
+    {:a [5 6] :b [10 11] :c [15 16]} #(merge-with vector % (TestType. 6 11 16))
+    [:a 5] #(find % :a)
+    nil #(find % :d)))
+
 

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -78,11 +78,6 @@
    (= {:a 5 :b 10 :c 15}
       (mem/deserialize (mem/serialize (TestType. 5 10 15) ::TestType) ::TestType))))
 
-(t/deftest can-define-nested-structs
-  (t/is
-   (eval
-    `(mem/defstruct ~'NestedTestType [::mem/int ~'x ::mem/byte ~'y ::TestType ~'z]))))
-
 (mem/defstruct NestedTestType [::mem/int x ::mem/byte y ::TestType z])
 
 (t/deftest can-instantiated-nested-structs
@@ -112,11 +107,6 @@
    (java.util.Arrays/equals
     (int-array [1 2 3 4])
     (.z (mem/deserialize (mem/serialize (ArrayTestType. 5 6 (int-array [1 2 3 4])) ::ArrayTestType) ::ArrayTestType)))))
-
-(t/deftest can-define-complex-structs
-  (t/is
-   (eval
-    `(mem/defstruct ~'ComplexTestType [[::mem/array ::ArrayTestType 4] ~'x ::mem/byte ~'y [::mem/array ::mem/int 4] ~'z ::NestedTestType ~'w]))))
 
 (mem/defstruct ComplexTestType [[::mem/array ::ArrayTestType 4] x ::mem/byte y [::mem/array ::mem/int 4] z ::NestedTestType w])
 

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -32,9 +32,9 @@
 (t/deftest can-define-struct
   (t/is
    (eval
-    `(mem/defstruct ~'TestType [::mem/int ~'a ::mem/byte ~'b]))))
+    `(mem/defstruct ~'TestType [~'a ::mem/int ~'b ::mem/byte]))))
 
-(mem/defstruct TestType [::mem/int a ::mem/byte b ::mem/short c])
+(mem/defstruct TestType [a ::mem/int b ::mem/byte c ::mem/short])
 
 (t/deftest can-initialize-struct
   (t/is (TestType. 5 10 15)))
@@ -78,7 +78,7 @@
    (= {:a 5 :b 10 :c 15}
       (mem/deserialize (mem/serialize (TestType. 5 10 15) ::TestType) ::TestType))))
 
-(mem/defstruct NestedTestType [::mem/int x ::mem/byte y ::TestType z])
+(mem/defstruct NestedTestType [x ::mem/int y ::mem/byte z ::TestType])
 
 (t/deftest can-instantiated-nested-structs
   (t/is
@@ -88,9 +88,9 @@
 (t/deftest can-define-structs-with-array-members
   (t/is
    (eval
-    `(mem/defstruct ~'ArrayTestType [::mem/int ~'x ::mem/byte ~'y [::mem/array ::mem/int 4 :raw? true] ~'z]))))
+    `(mem/defstruct ~'ArrayTestType [~'x ::mem/int ~'y ::mem/byte ~'z [::mem/array ::mem/int 4 :raw? true]]))))
 
-(mem/defstruct ArrayTestType [::mem/int x ::mem/byte y [::mem/array ::mem/int 4 :raw? true] z])
+(mem/defstruct ArrayTestType [x ::mem/int y ::mem/byte z [::mem/array ::mem/int 4 :raw? true]])
 
 (t/deftest can-instantiated-array-member-structs
   (t/are [x y z] (z x (y (ArrayTestType. 5 6 (int-array [1 2 3 4]))))
@@ -108,7 +108,7 @@
     (int-array [1 2 3 4])
     (.z (mem/deserialize (mem/serialize (ArrayTestType. 5 6 (int-array [1 2 3 4])) ::ArrayTestType) ::ArrayTestType)))))
 
-(mem/defstruct ComplexTestType [[::mem/array ::ArrayTestType 4 :raw? true] x ::mem/byte y [::mem/array ::mem/int 4 :raw? true] z ::NestedTestType w])
+(mem/defstruct ComplexTestType [x [::mem/array ::ArrayTestType 4 :raw? true] y ::mem/byte z [::mem/array ::mem/int 4 :raw? true] w ::NestedTestType])
 
 (t/deftest can-serialize-deserialize-complex-struct-type
   (t/is
@@ -121,7 +121,7 @@
       (mem/serialize ::ComplexTestType)
       (mem/deserialize ::ComplexTestType)))))
 
-(mem/defstruct ComplexTestTypeWrapped [[::mem/array ::ArrayTestType 4] x ::mem/byte y [::mem/array ::mem/int 4] z ::NestedTestType w])
+(mem/defstruct ComplexTestTypeWrapped [x [::mem/array ::ArrayTestType 4] y ::mem/byte z [::mem/array ::mem/int 4] w ::NestedTestType])
 
 (t/deftest can-serialize-deserialize-complex-wrapped-struct-type
   (t/is

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -76,3 +76,25 @@
    (= {:a 5 :b 10 :c 15}
       (mem/deserialize (mem/serialize (TestType. 5 10 15) ::TestType) ::TestType))))
 
+
+(t/deftest can-define-nested-structs
+  (t/is
+   (eval
+    `(mem/defstruct ~'NestedTestType [::mem/int ~'x ::mem/byte ~'y ::TestType ~'z]))))
+
+(t/deftest can-instantiated-nested-structs
+  (t/is
+   (= {:x 5 :y 6 :z {:a 5 :b 10 :c 15}}
+      (NestedTestType. 5 6 (TestType. 5 10 15)))))
+
+(t/deftest can-define-structs-with-array-members
+  (t/is
+   (eval
+    `(mem/defstruct ~'ArrayTestType [::mem/int ~'x ::mem/byte ~'y [::mem/array ::mem/int 4] ~'z]))))
+
+(t/deftest can-instantiated-array-member-structs
+  (t/are [x y z] (z x (y (ArrayTestType. 5 6 (int-array [1 2 3 4]))))
+      {:x 5 :y 6} #(dissoc % :z) =
+      (int-array [1 2 3 4]) :z java.util.Arrays/equals))
+
+

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -67,4 +67,12 @@
     (TestType. 5 10 15) identity
     (TestType. 5 10 15) (fn [s] {:a 5 :b 10 :c 15})))
 
+(t/deftest can-serialize-struct-type
+  (t/is
+   (instance? MemorySegment (mem/serialize (TestType. 5 10 15) ::TestType))))
+
+(t/deftest can-deserialize-struct-type
+  (t/is
+   (= {:a 5 :b 10 :c 15}
+      (mem/deserialize (mem/serialize (TestType. 5 10 15) ::TestType) ::TestType))))
 

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :as t]
    [coffi.ffi :as ffi]
-   [coffi.layout :as layout]
    [coffi.mem :as mem])
   (:import
    (java.lang.foreign

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -121,3 +121,16 @@
       (mem/serialize ::ComplexTestType)
       (mem/deserialize ::ComplexTestType)))))
 
+(mem/defstruct ComplexTestTypeWrapped [[::mem/array ::ArrayTestType 4] x ::mem/byte y [::mem/array ::mem/int 4] z ::NestedTestType w] :raw-arrays? false)
+
+(t/deftest can-serialize-deserialize-complex-wrapped-struct-type
+  (t/is
+   (let [x (vec (map #(ArrayTestType. % % (int-array (range 4))) (range 4)))
+         y 12
+         z (vec (range 4))
+         w (NestedTestType. 5 6 (TestType. 5 10 15))]
+     (->
+      (ComplexTestTypeWrapped. x y z w)
+      (mem/serialize ::ComplexTestTypeWrapped)
+      (mem/deserialize ::ComplexTestTypeWrapped)))))
+

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -88,9 +88,9 @@
 (t/deftest can-define-structs-with-array-members
   (t/is
    (eval
-    `(mem/defstruct ~'ArrayTestType [::mem/int ~'x ::mem/byte ~'y [::mem/array ::mem/int 4] ~'z]))))
+    `(mem/defstruct ~'ArrayTestType [::mem/int ~'x ::mem/byte ~'y [::mem/array ::mem/int 4 :raw? true] ~'z]))))
 
-(mem/defstruct ArrayTestType [::mem/int x ::mem/byte y [::mem/array ::mem/int 4] z])
+(mem/defstruct ArrayTestType [::mem/int x ::mem/byte y [::mem/array ::mem/int 4 :raw? true] z])
 
 (t/deftest can-instantiated-array-member-structs
   (t/are [x y z] (z x (y (ArrayTestType. 5 6 (int-array [1 2 3 4]))))
@@ -108,7 +108,7 @@
     (int-array [1 2 3 4])
     (.z (mem/deserialize (mem/serialize (ArrayTestType. 5 6 (int-array [1 2 3 4])) ::ArrayTestType) ::ArrayTestType)))))
 
-(mem/defstruct ComplexTestType [[::mem/array ::ArrayTestType 4] x ::mem/byte y [::mem/array ::mem/int 4] z ::NestedTestType w])
+(mem/defstruct ComplexTestType [[::mem/array ::ArrayTestType 4 :raw? true] x ::mem/byte y [::mem/array ::mem/int 4 :raw? true] z ::NestedTestType w])
 
 (t/deftest can-serialize-deserialize-complex-struct-type
   (t/is
@@ -121,7 +121,7 @@
       (mem/serialize ::ComplexTestType)
       (mem/deserialize ::ComplexTestType)))))
 
-(mem/defstruct ComplexTestTypeWrapped [[::mem/array ::ArrayTestType 4] x ::mem/byte y [::mem/array ::mem/int 4] z ::NestedTestType w] :raw-arrays? false)
+(mem/defstruct ComplexTestTypeWrapped [[::mem/array ::ArrayTestType 4] x ::mem/byte y [::mem/array ::mem/int 4] z ::NestedTestType w])
 
 (t/deftest can-serialize-deserialize-complex-wrapped-struct-type
   (t/is

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -62,6 +62,9 @@
     {:a [5 6] :b [10 11] :c [15 16]} #(merge-with vector % {:a 6 :b 11 :c 16})
     {:a [5 6] :b [10 11] :c [15 16]} #(merge-with vector % (TestType. 6 11 16))
     [:a 5] #(find % :a)
-    nil #(find % :d)))
+    nil #(find % :d)
+    {:a 5 :b 10 :c 15} identity
+    (TestType. 5 10 15) identity
+    (TestType. 5 10 15) (fn [s] {:a 5 :b 10 :c 15})))
 
 


### PR DESCRIPTION
~~[Note: I would consider this a draft PR, as I have not yet added tests (which could unearth some bugs and necessitate appropriate fixes).]~~

Hi, this PR contains the addition of a `defstruct` macro. It does the following:

* It adds serialize and deserialize code to a serde "registry" for the new type (details below)
* It generates a new type that has the specified members (details below)
* It adds an implmentation for `c-layout`
* It adds inline implementations for both `deserialize-from` and `serialize-into`
* It adds an implementation for `clojure.pprint/simple-dispatch`

## serde registry
The "registry" is implemented via the multimethods `generate-deserialize` and `generate-serialize` which produce code to de/serialize the respective types. This removes indirection in the de/serialize code for types that use other types. i think in the original discussion we were on the same page, but thought the other meant something different. The `defstruct` macro adds implementations to the multimethods for the newly generated type.

## the generated type
The new type is generated via `deftype` in the private function `generate-struct-record`. This is an attempt to strike a middle ground between the two positions of the original discussion, although the result might be a bit odd:

* The type implements both `IPersistentVector` **and** `IPersistentMap`. 
  * The basic idea is: if it is treated like a vector, it behaves like a vector. if it is treated like a map, it behaves like a map.
* It therefore implements both vector-like methods like `nth` as well as map-like methods like `without` (for e.g. `dissoc`). 
* If there is a an overlap in map/vector interface such as with `assoc`, it supports both paradigms of indices-as-keys and membernames-as-keys. Practically speaking, if you use something like `assoc` with a number as a key, it behaves like a vector (and will return a vector), otherwise like a map (and will return a map).
* one notable exception here is `foreach` which can't support both paradigms, and it is therefore implemented as if it's a vector. The rationale here is that the value of the type is composed of the actual values of the members, not the associated names of the places of the values. If you `map` or `reduce` over an object of this type, you will do so over the values of the members.
  
## with-c-layout
There was one implementation problem. Since padding was needed to be taken into account to allow for inline serdes, the new code for the macro needed to rely on `with-c-layout`. The problem here is that `with-c-layout` is in the `layout` namespace which already depends on `mem`. As a stopgap solution i simply copied the function over as a private function. I would be in favor of actually deprecating the `layout` namespace. for backwards compatibility the `with-c-layout` function in `layout` could depend on the one in `mem`. Not only is the `layout` namespace at this point somewhat anemic, it has also caused me trouble. I'm not sure if it's a bug, but due to `with-c-layout` being in `layout`, i ran into the problem that there are now two different `:padding` keywords, which i found confusing.

## tests & benchmarks
No tests or benchmarks exist right now. I don't *expect* the custom type to be slower than defrecord, but I want to test it.
Similarly, i do want to add a first set of tests for the de/serialization.