### PR TITLE
Add Boolean support

### DIFF
--- a/src/clj/coffi/ffi.clj
+++ b/src/clj/coffi/ffi.clj
@@ -61,6 +61,7 @@
 (def ^:private load-instructions
   "Mapping from primitive types to the instruction used to load them onto the stack."
   {::mem/byte :bload
+   ::mem/boolean :iload ; as per jvms 2.3.4 it should be iload. hmm
    ::mem/short :sload
    ::mem/int :iload
    ::mem/long :lload
@@ -72,6 +73,7 @@
 (def ^:private prim-classes
   "Mapping from primitive types to their box classes."
   {::mem/byte Byte
+   ::mem/boolean Boolean
    ::mem/short Short
    ::mem/int Integer
    ::mem/long Long
@@ -107,6 +109,7 @@
 (def ^:private unbox-fn-for-type
   "Map from type name to the name of its unboxing function."
   {::mem/byte "byteValue"
+   ::mem/boolean "booleanValue"
    ::mem/short "shortValue"
    ::mem/int "intValue"
    ::mem/long "longValue"
@@ -240,6 +243,7 @@
   "Map from non-pointer primitive types to functions that cast to the appropriate
   java primitive."
   {::mem/byte `byte
+   ::mem/boolean `boolean
    ::mem/short `short
    ::mem/int `int
    ::mem/long `long
@@ -467,6 +471,7 @@
 (def ^:private return-for-type
   "Map from type name to the return instruction for that type."
   {::mem/byte :breturn
+   ::mem/boolean :ireturn
    ::mem/short :sreturn
    ::mem/int :ireturn
    ::mem/long :lreturn

--- a/src/clj/coffi/ffi.clj
+++ b/src/clj/coffi/ffi.clj
@@ -240,7 +240,6 @@
   "Map from non-pointer primitive types to functions that cast to the appropriate
   java primitive."
   {::mem/byte `byte
-   ::mem/boolean `boolean
    ::mem/short `short
    ::mem/int `int
    ::mem/long `long
@@ -468,7 +467,10 @@
 (def ^:private return-for-type
   "Map from type name to the return instruction for that type."
   {::mem/byte :breturn
-   ::mem/boolean :ireturn
+   [::mem/bool 8] :ireturn
+   [::mem/bool 16] :ireturn
+   [::mem/bool 32] :ireturn
+   [::mem/bool 64] :lreturn
    ::mem/short :sreturn
    ::mem/int :ireturn
    ::mem/long :lreturn

--- a/src/clj/coffi/ffi.clj
+++ b/src/clj/coffi/ffi.clj
@@ -61,7 +61,6 @@
 (def ^:private load-instructions
   "Mapping from primitive types to the instruction used to load them onto the stack."
   {::mem/byte :bload
-   ::mem/boolean :iload ; as per jvms 2.3.4 it should be iload. hmm
    ::mem/short :sload
    ::mem/int :iload
    ::mem/long :lload
@@ -73,7 +72,6 @@
 (def ^:private prim-classes
   "Mapping from primitive types to their box classes."
   {::mem/byte Byte
-   ::mem/boolean Boolean
    ::mem/short Short
    ::mem/int Integer
    ::mem/long Long
@@ -109,7 +107,6 @@
 (def ^:private unbox-fn-for-type
   "Map from type name to the name of its unboxing function."
   {::mem/byte "byteValue"
-   ::mem/boolean "booleanValue"
    ::mem/short "shortValue"
    ::mem/int "intValue"
    ::mem/long "longValue"

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -243,7 +243,7 @@
   ValueLayout/ADDRESS)
 
 (def ^long boolean-size
-  "The size in bytes of a c-sized boolean."
+  "The size in bytes of the layout of a java boolean."
   (.byteSize boolean-layout))
 
 (def ^long short-size

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1198,7 +1198,7 @@
   [type]
   (contains? primitive-types (type-dispatch type)))
 
-(defn- throw-illegal-bool! [] (throw IllegalArgumentException _ "encountered bool type without explicit size! use e.g. [::mem/bool 8] or [::mem/bool 32] instead."))
+(defn- throw-illegal-bool! [] (throw (IllegalArgumentException. "encountered bool type without explicit size! use e.g. [::mem/bool 8] or [::mem/bool 32] instead.")))
 
 (defmulti primitive-type
   "Gets the primitive type that is used to pass as an argument for the `type`.
@@ -1287,7 +1287,7 @@
 
 (defmethod c-layout ::bool [type]
   (if (sequential? type)
-    (case (second type) 8 mem/byte-layout 16 mem/short-layout 32 mem/int-layout 64 mem/long-layout)
+    (case (second type) 8 byte-layout 16 short-layout 32 int-layout 64 long-layout)
     (throw-illegal-bool!)))
 
 (defmethod c-layout ::short

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1955,37 +1955,37 @@
 
 (defn- coffitype->array-fn [type]
   (get
-   {:coffi.mem/byte    `byte-array
-    [::bool 8]         `boolean-array
-    [::bool 16]        `boolean-array
-    [::bool 32]        `boolean-array
-    [::bool 64]        `boolean-array
-    :coffi.mem/short   `short-array
-    :coffi.mem/int     `int-array
-    :coffi.mem/long    `long-array
-    :coffi.mem/char    `char-array
-    :coffi.mem/float   `float-array
-    :coffi.mem/double  `double-array}
+   {:coffi.mem/byte   `byte-array
+    [::bool 8]        `boolean-array
+    [::bool 16]       `boolean-array
+    [::bool 32]       `boolean-array
+    [::bool 64]       `boolean-array
+    :coffi.mem/short  `short-array
+    :coffi.mem/int    `int-array
+    :coffi.mem/long   `long-array
+    :coffi.mem/char   `char-array
+    :coffi.mem/float  `float-array
+    :coffi.mem/double `double-array}
    type
    `object-array))
 
 (defn- coffitype->array-write-fn [type]
-  ({:coffi.mem/byte    `write-bytes
-    :coffi.mem/short   `write-shorts
-    :coffi.mem/int     `write-ints
-    :coffi.mem/long    `write-longs
-    :coffi.mem/char    `write-chars
-    :coffi.mem/float   `write-floats
-    :coffi.mem/double  `write-doubles} type))
+  ({:coffi.mem/byte   `write-bytes
+    :coffi.mem/short  `write-shorts
+    :coffi.mem/int    `write-ints
+    :coffi.mem/long   `write-longs
+    :coffi.mem/char   `write-chars
+    :coffi.mem/float  `write-floats
+    :coffi.mem/double `write-doubles} type))
 
 (defn- coffitype->array-read-fn [type]
-  ({:coffi.mem/byte    `read-bytes
-    :coffi.mem/short   `read-shorts
-    :coffi.mem/int     `read-ints
-    :coffi.mem/long    `read-longs
-    :coffi.mem/char    `read-chars
-    :coffi.mem/float   `read-floats
-    :coffi.mem/double  `read-doubles} type))
+  ({:coffi.mem/byte   `read-bytes
+    :coffi.mem/short  `read-shorts
+    :coffi.mem/int    `read-ints
+    :coffi.mem/long   `read-longs
+    :coffi.mem/char   `read-chars
+    :coffi.mem/float  `read-floats
+    :coffi.mem/double `read-doubles} type))
 
 (defmulti  generate-deserialize (fn [& xs] (if (vector? (first xs)) (ffirst xs) (first xs))))
 

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -570,29 +570,6 @@
   ([^MemorySegment segment ^long offset value]
    (.set segment ^ValueLayout$OfByte byte-layout offset ^byte value)))
 
-(defn write-boolean
-  "Writes a [[boolean]] to the `segment`, at an optional `offset`.
-
-  If `byte-order` is not provided, it defaults to [[native-endian]]."
-  {:inline
-   (fn write-boolean-inline
-     ([segment value]
-      (once-only [^java.lang.foreign.MemorySegment segment ^boolean value]
-        `(.set ~segment ^ValueLayout$OfBoolean boolean-layout 0 ~value)))
-     ([segment offset value]
-      (once-only [^java.lang.foreign.MemorySegment segment ^long offset ^boolean value]
-        `(.set ~segment ^ValueLayout$OfBoolean boolean-layout ~offset ~value)))
-     ([segment offset byte-order value]
-      (once-only [^java.lang.foreign.MemorySegment segment ^long offset
-                  ^java.nio.ByteOrder byte-order ^boolean value]
-        `(.set ~segment (.withOrder ^ValueLayout$OfBoolean boolean-layout ~byte-order) ~offset ~value))))}
-  ([^MemorySegment segment value]
-   (.set segment ^ValueLayout$OfBoolean boolean-layout 0 ^boolean value))
-  ([^MemorySegment segment ^long offset value]
-   (.set segment ^ValueLayout$OfBoolean boolean-layout offset ^boolean value))
-  ([^MemorySegment segment ^long offset ^ByteOrder byte-order value]
-   (.set segment (.withOrder ^ValueLayout$OfBoolean boolean-layout byte-order) offset ^boolean value)))
-
 (defn write-short
   "Writes a [[short]] to the `segment`, at an optional `offset`.
 
@@ -615,6 +592,7 @@
    (.set segment ^ValueLayout$OfShort short-layout offset ^short value))
   ([^MemorySegment segment ^long offset ^ByteOrder byte-order value]
    (.set segment (.withOrder ^ValueLayout$OfShort short-layout byte-order) offset ^short value)))
+
 
 (defn write-int
   "Writes a [[int]] to the `segment`, at an optional `offset`.
@@ -661,6 +639,78 @@
    (.set segment ^ValueLayout$OfLong long-layout offset value))
   (^long [^MemorySegment segment ^long offset ^ByteOrder byte-order ^long value]
    (.set segment (.withOrder ^ValueLayout$OfLong long-layout byte-order) offset value)))
+
+(defn write-bool-8
+  "Writes a [[bool]] of 8 bits (byte size 1) to the `segment`, at an optional `offset`.
+
+  If `byte-order` is not provided, it defaults to [[native-endian]]."
+  {:inline
+   (fn write-bool-8-inline
+     ([segment value]
+      `(write-byte ~segment (if ~value 1 0)))
+     ([segment offset value]
+      `(write-byte ~segment ~offset (if ~value 1 0))))}
+  ([^MemorySegment segment value]
+   (write-byte segment (if value 1 0)))
+  ([^MemorySegment segment ^long offset value]
+   (write-byte segment offset (if value 1 0))))
+
+(defn write-bool-16
+  "Writes a [[bool]] of 16 bits (byte size 2) to the `segment`, at an optional `offset`.
+
+  If `byte-order` is not provided, it defaults to [[native-endian]]."
+  {:inline
+   (fn write-bool-16-inline
+     ([segment value]
+      `(write-short ~segment (if ~value 1 0)))
+     ([segment offset value]
+      `(write-short ~segment ~offset (if ~value 1 0)))
+     ([segment value offset byte-order value]
+      `(write-short ~segment ~offset ~byte-order (if ~value 1 0))))}
+  ([^MemorySegment segment value]
+   (write-short segment (if value 1 0)))
+  ([^MemorySegment segment ^long offset value]
+   (write-short segment offset (if value 1 0)))
+  ([^MemorySegment segment ^long offset ^ByteOrder byte-order value]
+   (write-short segment offset byte-order (if value 1 0))))
+
+(defn write-bool-32
+  "Writes a [[bool]] of 32 bits (byte size 4) to the `segment`, at an optional `offset`.
+
+  If `byte-order` is not provided, it defaults to [[native-endian]]."
+  {:inline
+   (fn write-bool-32-inline
+     ([segment value]
+      `(write-int ~segment (if ~value 1 0)))
+     ([segment offset value]
+      `(write-int ~segment ~offset (if ~value 1 0)))
+     ([segment value offset byte-order value]
+      `(write-int ~segment ~offset ~byte-order (if ~value 1 0))))}
+  ([^MemorySegment segment value]
+   (write-int segment (if value 1 0)))
+  ([^MemorySegment segment ^long offset value]
+   (write-int segment offset (if value 1 0)))
+  ([^MemorySegment segment ^long offset ^ByteOrder byte-order value]
+   (write-int segment offset byte-order (if value 1 0))))
+
+(defn write-bool-64
+  "Writes a [[bool]] of 64 bits (byte size 8) to the `segment`, at an optional `offset`.
+
+  If `byte-order` is not provided, it defaults to [[native-endian]]."
+  {:inline
+   (fn write-bool-64inline
+     ([segment value]
+      `(write-long ~segment (if ~value 1 0)))
+     ([segment offset value]
+      `(write-long ~segment ~offset (if ~value 1 0)))
+     ([segment value offset byte-order value]
+      `(write-long ~segment ~offset ~byte-order (if ~value 1 0))))}
+  ([^MemorySegment segment value]
+   (write-long segment (if value 1 0)))
+  ([^MemorySegment segment ^long offset value]
+   (write-long segment offset (if value 1 0)))
+  ([^MemorySegment segment ^long offset ^ByteOrder byte-order value]
+   (write-long segment offset byte-order (if value 1 0))))
 
 (defn write-char
   "Writes a [[char]] to the `segment`, at an optional `offset`."
@@ -1359,9 +1409,12 @@
   [obj _type _arena]
   (byte obj))
 
-(defmethod serialize* ::boolean
-  [obj _type _arena]
-  (boolean obj))
+(defmethod serialize* ::bool
+  [obj type _arena]
+  (let [v (if obj 1 0)]
+    (if (sequential? type)
+      (case (second type) 8 (byte v) 16 (short v) 32 (int v) 64 (long v))
+      (throw-illegal-bool!))))
 
 (defmethod serialize* ::short
   [obj _type _arena]
@@ -1432,8 +1485,12 @@
 (defmethod serialize-into ::boolean
   [obj type segment _arena]
   (if (sequential? type)
-    (write-boolean segment 0 (second type) (boolean obj))
-    (write-boolean segment (boolean obj))))
+    (case (second type)
+      8  (write-bool-8 segment obj)
+      16 (write-bool-16 segment obj)
+      32 (write-bool-32 segment obj)
+      64 (write-bool-64 segment obj))
+    (throw-illegal-bool!)))
 
 (defmethod serialize-into ::short
   [obj type segment _arena]

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -811,23 +811,6 @@
   ([^MemorySegment segment n offset ^bytes value]
    (MemorySegment/copy value 0 segment ^ValueLayout$OfByte byte-layout ^long offset ^int n)))
 
-(defn write-booleans
-  "Writes n elements from a [[boolean]] array to the `segment`, at an optional `offset`.
-
-  If `byte-order` is not provided, it defaults to [[native-endian]]."
-  {:inline
-   (fn write-boolean-inline
-     ([segment n value]
-      (once-only [^java.lang.foreign.MemorySegment segment ^booleans value]
-        `(MemorySegment/copy ~value 0 ~segment ^ValueLayout$OfBoolean boolean-layout 0 ~n)))
-     ([segment n offset value]
-      (once-only [^java.lang.foreign.MemorySegment segment ^long offset ^booleans value]
-        `(MemorySegment/copy ~value 0 ~segment ^ValueLayout$OfBoolean boolean-layout ~offset ~n))))}
-  ([^MemorySegment segment n ^booleans value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfBoolean boolean-layout 0 ^int n))
-  ([^MemorySegment segment n ^long offset ^booleans value]
-   (MemorySegment/copy value 0 segment ^ValueLayout$OfBoolean boolean-layout ^long offset ^int n)))
-
 (defn write-shorts
   "Writes n elements from a [[short]] array to the `segment`, at an optional `offset`.
 
@@ -1949,23 +1932,29 @@
   (let [[indirect-type type n & {:keys [raw?] :as opts}] (if (vector? in) in [:- in])
         arr? (= indirect-type ::array)
         ptr? (= indirect-type ::pointer)
-        array-types  {::byte     'bytes
-                      ::boolean  'booleans
-                      ::short    'shorts
-                      ::int      'ints
-                      ::long     'longs
-                      ::char     'chars
-                      ::float    'floats
-                      ::double   'doubles}
-        single-types {::byte     'byte
-                      ::boolean  'boolean
-                      ::short    'short
-                      ::int      'int
-                      ::long     'long
-                      ::char     'char
-                      ::float    'float
-                      ::double   'double
-                      ::c-string 'String}]
+        array-types  {::byte      'bytes
+                      [::bool 8]  'booleans
+                      [::bool 16] 'booleans
+                      [::bool 32] 'booleans
+                      [::bool 64] 'booleans
+                      ::short     'shorts
+                      ::int       'ints
+                      ::long      'longs
+                      ::char      'chars
+                      ::float     'floats
+                      ::double    'doubles}
+        single-types {::byte      'byte
+                      [::bool 8]  'boolean
+                      [::bool 16] 'boolean
+                      [::bool 32] 'boolean
+                      [::bool 64] 'boolean
+                      ::short     'short
+                      ::int       'int
+                      ::long      'long
+                      ::char      'char
+                      ::float     'float
+                      ::double    'double
+                      ::c-string  'String}]
     (cond (and arr? raw?) (get array-types type 'objects)
           (and arr?)      `clojure.lang.IPersistentVector
           (and ptr?)      `java.lang.foreign.MemorySegment
@@ -1974,7 +1963,10 @@
 (defn- coffitype->array-fn [type]
   (get
    {:coffi.mem/byte    `byte-array
-    :coffi.mem/boolean `boolean-array
+    [::bool 8]         `boolean-array
+    [::bool 16]        `boolean-array
+    [::bool 32]        `boolean-array
+    [::bool 64]        `boolean-array
     :coffi.mem/short   `short-array
     :coffi.mem/int     `int-array
     :coffi.mem/long    `long-array
@@ -1986,7 +1978,6 @@
 
 (defn- coffitype->array-write-fn [type]
   ({:coffi.mem/byte    `write-bytes
-    :coffi.mem/boolean `write-booleans
     :coffi.mem/short   `write-shorts
     :coffi.mem/int     `write-ints
     :coffi.mem/long    `write-longs
@@ -1996,7 +1987,6 @@
 
 (defn- coffitype->array-read-fn [type]
   ({:coffi.mem/byte    `read-bytes
-    :coffi.mem/boolean `read-shorts
     :coffi.mem/short   `read-shorts
     :coffi.mem/int     `read-ints
     :coffi.mem/long    `read-longs

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -647,13 +647,13 @@
   {:inline
    (fn write-bool-8-inline
      ([segment value]
-      `(write-byte ~segment (if ~value 1 0)))
+      `(write-byte ~segment (if ~value -1 0)))
      ([segment offset value]
-      `(write-byte ~segment ~offset (if ~value 1 0))))}
+      `(write-byte ~segment ~offset (if ~value -1 0))))}
   ([^MemorySegment segment value]
-   (write-byte segment (if value 1 0)))
+   (write-byte segment (if value -1 0)))
   ([^MemorySegment segment ^long offset value]
-   (write-byte segment offset (if value 1 0))))
+   (write-byte segment offset (if value -1 0))))
 
 (defn write-bool-16
   "Writes a [[bool]] of 16 bits (byte size 2) to the `segment`, at an optional `offset`.
@@ -662,17 +662,17 @@
   {:inline
    (fn write-bool-16-inline
      ([segment value]
-      `(write-short ~segment (if ~value 1 0)))
+      `(write-short ~segment (if ~value -1 0)))
      ([segment offset value]
-      `(write-short ~segment ~offset (if ~value 1 0)))
+      `(write-short ~segment ~offset (if ~value -1 0)))
      ([segment value offset byte-order value]
-      `(write-short ~segment ~offset ~byte-order (if ~value 1 0))))}
+      `(write-short ~segment ~offset ~byte-order (if ~value -1 0))))}
   ([^MemorySegment segment value]
-   (write-short segment (if value 1 0)))
+   (write-short segment (if value -1 0)))
   ([^MemorySegment segment ^long offset value]
-   (write-short segment offset (if value 1 0)))
+   (write-short segment offset (if value -1 0)))
   ([^MemorySegment segment ^long offset ^ByteOrder byte-order value]
-   (write-short segment offset byte-order (if value 1 0))))
+   (write-short segment offset byte-order (if value -1 0))))
 
 (defn write-bool-32
   "Writes a [[bool]] of 32 bits (byte size 4) to the `segment`, at an optional `offset`.
@@ -681,17 +681,17 @@
   {:inline
    (fn write-bool-32-inline
      ([segment value]
-      `(write-int ~segment (if ~value 1 0)))
+      `(write-int ~segment (if ~value -1 0)))
      ([segment offset value]
-      `(write-int ~segment ~offset (if ~value 1 0)))
+      `(write-int ~segment ~offset (if ~value -1 0)))
      ([segment value offset byte-order value]
-      `(write-int ~segment ~offset ~byte-order (if ~value 1 0))))}
+      `(write-int ~segment ~offset ~byte-order (if ~value -1 0))))}
   ([^MemorySegment segment value]
-   (write-int segment (if value 1 0)))
+   (write-int segment (if value -1 0)))
   ([^MemorySegment segment ^long offset value]
-   (write-int segment offset (if value 1 0)))
+   (write-int segment offset (if value -1 0)))
   ([^MemorySegment segment ^long offset ^ByteOrder byte-order value]
-   (write-int segment offset byte-order (if value 1 0))))
+   (write-int segment offset byte-order (if value -1 0))))
 
 (defn write-bool-64
   "Writes a [[bool]] of 64 bits (byte size 8) to the `segment`, at an optional `offset`.
@@ -700,17 +700,17 @@
   {:inline
    (fn write-bool-64inline
      ([segment value]
-      `(write-long ~segment (if ~value 1 0)))
+      `(write-long ~segment (if ~value -1 0)))
      ([segment offset value]
-      `(write-long ~segment ~offset (if ~value 1 0)))
+      `(write-long ~segment ~offset (if ~value -1 0)))
      ([segment value offset byte-order value]
-      `(write-long ~segment ~offset ~byte-order (if ~value 1 0))))}
+      `(write-long ~segment ~offset ~byte-order (if ~value -1 0))))}
   ([^MemorySegment segment value]
-   (write-long segment (if value 1 0)))
+   (write-long segment (if value -1 0)))
   ([^MemorySegment segment ^long offset value]
-   (write-long segment offset (if value 1 0)))
+   (write-long segment offset (if value -1 0)))
   ([^MemorySegment segment ^long offset ^ByteOrder byte-order value]
-   (write-long segment offset byte-order (if value 1 0))))
+   (write-long segment offset byte-order (if value -1 0))))
 
 (defn write-char
   "Writes a [[char]] to the `segment`, at an optional `offset`."
@@ -1411,7 +1411,7 @@
 
 (defmethod serialize* ::bool
   [obj type _arena]
-  (let [v (if obj 1 0)]
+  (let [v (if obj -1 0)]
     (if (sequential? type)
       (case (second type) 8 (byte v) 16 (short v) 32 (int v) 64 (long v))
       (throw-illegal-bool!))))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -299,7 +299,7 @@
   (.byteAlignment pointer-layout))
 
 (def ^:private primitive-tag?
-  '#{byte boolean bytes short shorts int ints long longs
+  '#{byte bytes short shorts int ints long longs
      float floats double doubles
      bool bools char chars})
 
@@ -1190,7 +1190,7 @@
 
 (def primitive-types
   "A set of all primitive types."
-  #{::byte ::boolean ::short ::int ::long
+  #{::byte ::bool ::short ::int ::long
     ::char ::float ::double ::pointer})
 
 (defn primitive?

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -332,31 +332,6 @@
   ([^MemorySegment segment ^long offset]
    (.get segment ^ValueLayout$OfByte byte-layout offset)))
 
-(defn read-boolean
-  "Reads a [[boolean]] from the `segment`, at an optional `offset`.
-
-  If `byte-order` is not provided, it defaults to [[native-endian]]."
-  {:inline
-   (fn read-boolean-inline
-     ([segment]
-      `(let [segment# ~segment]
-         (.get ^MemorySegment segment# ^ValueLayout$OfBoolean boolean-layout 0)))
-     ([segment offset]
-      `(let [segment# ~segment
-             offset# ~offset]
-         (.get ^MemorySegment segment# ^ValueLayout$OfBoolean boolean-layout offset#)))
-     ([segment offset byte-order]
-      `(let [segment# ~segment
-             offset# ~offset
-             byte-order# ~byte-order]
-         (.get ^MemorySegment segment# (.withOrder ^ValueLayout$OfBoolean boolean-layout ^ByteOrder byte-order#) offset#))))}
-  ([^MemorySegment segment]
-   (.get segment ^ValueLayout$OfBoolean boolean-layout 0))
-  ([^MemorySegment segment ^long offset]
-   (.get segment ^ValueLayout$OfBoolean boolean-layout offset))
-  ([^MemorySegment segment ^long offset ^ByteOrder byte-order]
-   (.get segment (.withOrder ^ValueLayout$OfBoolean boolean-layout byte-order) offset)))
-
 (defn read-short
   "Reads a [[short]] from the `segment`, at an optional `offset`.
 
@@ -431,6 +406,72 @@
    (.get segment ^ValueLayout$OfLong long-layout offset))
   (^long [^MemorySegment segment ^long offset ^ByteOrder byte-order]
    (.get segment (.withOrder ^ValueLayout$OfLong long-layout byte-order) offset)))
+
+(defn read-bool-8
+  "Reads a [[bool]] of 8 bits (byte size of 1) from the `segment`, at an optional `offset`."
+  {:inline
+   (fn read-bool-8-inline
+     ([segment] `(not (zero? (read-byte ~segment))))
+     ([segment offset] `(not (zero? (read-byte ~segment ~offset)))))}
+  ([^MemorySegment segment] (not (zero? (read-byte segment))))
+  ([^MemorySegment segment ^long offset] (not (zero? (read-byte segment offset)))))
+
+(defn read-bool-16
+  "Reads a [[bool]] of 16 bits (byte size of 2) from the `segment`, at an optional `offset`.
+
+  If `byte-order` is not provided, it defaults to [[native-endian]]."
+  {:inline
+   (fn read-read-bool-16-inline
+     ([segment]
+      `(not (zero? (read-short ~segment))))
+     ([segment offset]
+      `(not (zero? (read-short ~segment ~offset))))
+     ([segment offset byte-order]
+      `(not (zero? (read-short ~segment ~offset ~byte-order)))))}
+  ([^MemorySegment segment]
+   (not (zero? (read-short segment))))
+  ([^MemorySegment segment ^long offset]
+   (not (zero? (read-short segment offset))))
+  ([^MemorySegment segment ^long offset ^ByteOrder byte-order]
+   (not (zero? (read-short segment offset byte-order)))))
+
+(defn read-bool-32
+  "Reads a [[bool]] of 32 bits (byte size of 4) from the `segment`, at an optional `offset`.
+
+  If `byte-order` is not provided, it defaults to [[native-endian]]."
+  {:inline
+   (fn read-read-bool-32-inline
+     ([segment]
+      `(not (zero? (read-int ~segment))))
+     ([segment offset]
+      `(not (zero? (read-int ~segment ~offset))))
+     ([segment offset byte-order]
+      `(not (zero? (read-int ~segment ~offset ~byte-order)))))}
+  ([^MemorySegment segment]
+   (not (zero? (read-int segment))))
+  ([^MemorySegment segment ^long offset]
+   (not (zero? (read-int segment offset))))
+  ([^MemorySegment segment ^long offset ^ByteOrder byte-order]
+   (not (zero? (read-int segment offset byte-order)))))
+
+(defn read-bool-64
+  "Reads a [[bool]] of 64 bits (byte size of 8) from the `segment`, at an optional `offset`.
+
+  If `byte-order` is not provided, it defaults to [[native-endian]]."
+  {:inline
+   (fn read-read-bool-64-inline
+     ([segment]
+      `(not (zero? (read-long ~segment))))
+     ([segment offset]
+      `(not (zero? (read-long ~segment ~offset))))
+     ([segment offset byte-order]
+      `(not (zero? (read-long ~segment ~offset ~byte-order)))))}
+  ([^MemorySegment segment]
+   (not (zero? (read-long segment))))
+  ([^MemorySegment segment ^long offset]
+   (not (zero? (read-long segment offset))))
+  ([^MemorySegment segment ^long offset ^ByteOrder byte-order]
+   (not (zero? (read-long segment offset byte-order)))))
 
 (defn read-char
   "Reads a [[char]] from the `segment`, at an optional `offset`."
@@ -1124,6 +1165,8 @@
   [type]
   (contains? primitive-types (type-dispatch type)))
 
+(defn- throw-illegal-bool! [] (throw IllegalArgumentException _ "encountered bool type without explicit size! use e.g. [::mem/bool 8] or [::mem/bool 32] instead."))
+
 (defmulti primitive-type
   "Gets the primitive type that is used to pass as an argument for the `type`.
 
@@ -1148,6 +1191,11 @@
 (defmethod primitive-type ::boolean
   [_type]
   ::boolean)
+
+(defmethod primitive-type ::bool [type]
+  (if (sequential? type)
+    (case (second type) 8 ::byte 16 ::short 32 ::int 64 ::long)
+    (throw-illegal-bool!)))
 
 (defmethod primitive-type ::short
   [_type]
@@ -1203,6 +1251,11 @@
   (if (sequential? type)
     (.withOrder boolean-layout ^ByteOrder (second type))
     boolean-layout))
+
+(defmethod c-layout ::bool [type]
+  (if (sequential? type)
+    (case (second type) 8 mem/byte-layout 16 mem/short-layout 32 mem/int-layout 64 mem/long-layout)
+    (throw-illegal-bool!)))
 
 (defmethod c-layout ::short
   [type]
@@ -1463,11 +1516,15 @@
   [segment _type]
   (read-byte segment))
 
-(defmethod deserialize-from ::boolean
+(defmethod deserialize-from ::bool
   [segment type]
   (if (sequential? type)
-    (read-boolean segment 0 (second type))
-    (read-boolean segment)))
+    (case (second type)
+      8 (read-bool-8 segment)
+      16 (read-bool-16 segment)
+      32 (read-bool-32 segment)
+      64 (read-bool-64 segment))
+    (throw-illegal-bool!)))
 
 (defmethod deserialize-from ::short
   [segment type]
@@ -1528,9 +1585,9 @@
   [obj _type]
   obj)
 
-(defmethod deserialize* ::boolean
+(defmethod deserialize* ::bool
   [obj _type]
-  obj)
+  (not (zero? obj)))
 
 (defmethod deserialize* ::short
   [obj _type]

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1227,7 +1227,7 @@
 
 (defmethod primitive-type ::bool [type]
   (if (sequential? type)
-    (case (second type) 8 ::byte 16 ::short 32 ::int 64 ::long)
+    (case (long (second type)) 8 ::byte 16 ::short 32 ::int 64 ::long)
     (throw-illegal-bool!)))
 
 (defmethod primitive-type ::short
@@ -1287,7 +1287,7 @@
 
 (defmethod c-layout ::bool [type]
   (if (sequential? type)
-    (case (second type) 8 byte-layout 16 short-layout 32 int-layout 64 long-layout)
+    (case (long (second type)) 8 byte-layout 16 short-layout 32 int-layout 64 long-layout)
     (throw-illegal-bool!)))
 
 (defmethod c-layout ::short
@@ -1396,7 +1396,7 @@
   [obj type _arena]
   (let [v (if obj -1 0)]
     (if (sequential? type)
-      (case (second type) 8 (byte v) 16 (short v) 32 (int v) 64 (long v))
+      (case (long (second type)) 8 (byte v) 16 (short v) 32 (int v) 64 (long v))
       (throw-illegal-bool!))))
 
 (defmethod serialize* ::short
@@ -1468,7 +1468,7 @@
 (defmethod serialize-into ::boolean
   [obj type segment _arena]
   (if (sequential? type)
-    (case (second type)
+    (case (long (second type))
       8  (write-bool-8 segment obj)
       16 (write-bool-16 segment obj)
       32 (write-bool-32 segment obj)
@@ -1559,7 +1559,7 @@
 (defmethod deserialize-from ::bool
   [segment type]
   (if (sequential? type)
-    (case (second type)
+    (case (long (second type))
       8 (read-bool-8 segment)
       16 (read-bool-16 segment)
       32 (read-bool-32 segment)

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1997,7 +1997,6 @@
 (defmulti  generate-deserialize (fn [& xs] (if (vector? (first xs)) (ffirst xs) (first xs))))
 
 (defmethod generate-deserialize :coffi.mem/byte     [_type offset segment-source-form] `(read-byte    ~segment-source-form ~offset))
-(defmethod generate-deserialize :coffi.mem/boolean  [_type offset segment-source-form] `(read-boolean ~segment-source-form ~offset))
 (defmethod generate-deserialize :coffi.mem/short    [_type offset segment-source-form] `(read-short   ~segment-source-form ~offset))
 (defmethod generate-deserialize :coffi.mem/int      [_type offset segment-source-form] `(read-int     ~segment-source-form ~offset))
 (defmethod generate-deserialize :coffi.mem/long     [_type offset segment-source-form] `(read-long    ~segment-source-form ~offset))
@@ -2007,6 +2006,13 @@
 (defmethod generate-deserialize :coffi.mem/pointer  [_type offset segment-source-form] `(read-address ~segment-source-form ~offset))
 (defmethod generate-deserialize :coffi.mem/c-string [_type offset segment-source-form]
   `(.getString (.reinterpret (.get ~(with-meta segment-source-form {:tag 'java.lang.foreign.MemorySegment}) pointer-layout ~offset) Integer/MAX_VALUE) 0))
+
+(defmethod generate-deserialize ::bool [type offset segment-source-form]
+  (if (sequential? type)
+    `(~(case (long (second type)) 8 `read-bool-8 16 `read-bool-16 32 `read-bool-32 64 `read-bool-64)
+      ~segment-source-form
+      ~offset)
+    (throw-illegal-bool!)))
 
 (defn- generate-deserialize-array-as-array-bulk [array-type n offset segment-source-form]
   (list (coffitype->array-read-fn array-type) segment-source-form n offset))
@@ -2073,7 +2079,6 @@
 (defmulti  generate-serialize (fn [& xs] (if (vector? (first xs)) (ffirst xs) (first xs))))
 
 (defmethod generate-serialize :coffi.mem/byte     [_type source-form offset segment-source-form] `(write-byte    ~segment-source-form ~offset ~source-form))
-(defmethod generate-serialize :coffi.mem/boolean  [_type source-form offset segment-source-form] `(write-boolean ~segment-source-form ~offset ~source-form))
 (defmethod generate-serialize :coffi.mem/short    [_type source-form offset segment-source-form] `(write-short   ~segment-source-form ~offset ~source-form))
 (defmethod generate-serialize :coffi.mem/int      [_type source-form offset segment-source-form] `(write-int     ~segment-source-form ~offset ~source-form))
 (defmethod generate-serialize :coffi.mem/long     [_type source-form offset segment-source-form] `(write-long    ~segment-source-form ~offset ~source-form))
@@ -2082,6 +2087,14 @@
 (defmethod generate-serialize :coffi.mem/double   [_type source-form offset segment-source-form] `(write-double  ~segment-source-form ~offset ~source-form))
 (defmethod generate-serialize :coffi.mem/pointer  [_type source-form offset segment-source-form] `(write-address ~segment-source-form ~offset ~source-form))
 (defmethod generate-serialize :coffi.mem/c-string [_type source-form offset segment-source-form] `(write-address ~segment-source-form ~offset (.allocateFrom (Arena/ofAuto) ~source-form)))
+
+(defmethod generate-serialize ::bool [type source-form offset segment-source-form]
+  (if (sequential? type)
+    `(~(case (long (second type)) 8 `write-bool-8 16 `write-bool-16 32 `write-bool-32 64 `write-bool-64)
+      ~segment-source-form
+      ~offset
+      ~source-form)
+    (throw-illegal-bool!)))
 
 (defn- generate-serialize-array-as-array-bulk [member-type length source-form offset segment-source-form]
   (list (coffitype->array-write-fn member-type) segment-source-form length offset source-form))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1465,7 +1465,7 @@
   [obj _type segment _arena]
   (write-byte segment obj))
 
-(defmethod serialize-into ::boolean
+(defmethod serialize-into ::bool
   [obj type segment _arena]
   (if (sequential? type)
     (case (long (second type))

--- a/src/clj/coffi/mem.clj
+++ b/src/clj/coffi/mem.clj
@@ -1221,10 +1221,6 @@
   [_type]
   ::byte)
 
-(defmethod primitive-type ::boolean
-  [_type]
-  ::boolean)
-
 (defmethod primitive-type ::bool [type]
   (if (sequential? type)
     (case (long (second type)) 8 ::byte 16 ::short 32 ::int 64 ::long)
@@ -1279,12 +1275,6 @@
   [_type]
   byte-layout)
 
-(defmethod c-layout ::boolean
-  [type]
-  (if (sequential? type)
-    (.withOrder boolean-layout ^ByteOrder (second type))
-    boolean-layout))
-
 (defmethod c-layout ::bool [type]
   (if (sequential? type)
     (case (long (second type)) 8 byte-layout 16 short-layout 32 int-layout 64 long-layout)
@@ -1331,10 +1321,13 @@
 (def java-prim-layout
   "Map of primitive type names to the Java types for a method handle."
   {::byte Byte/TYPE
-   ::boolean Boolean/TYPE
    ::short Short/TYPE
    ::int Integer/TYPE
    ::long Long/TYPE
+   [::bool 8] Byte/TYPE
+   [::bool 16] Short/TYPE
+   [::bool 32] Integer/TYPE
+   [::bool 64] Long/TYPE
    ::char Byte/TYPE
    ::float Float/TYPE
    ::double Double/TYPE

--- a/test/clj/coffi/ffi_test.clj
+++ b/test/clj/coffi/ffi_test.clj
@@ -23,6 +23,12 @@
     (= true ((ffi/cfn "add_numbers" [::mem/int ::mem/int] [::mem/bool 32]) 2 2))
     (= false ((ffi/cfn "add_numbers" [::mem/int ::mem/int] [::mem/bool 32]) 2 -2)))))
 
+(t/deftest unsized-bool-function-throws
+  (t/is
+   (and
+    (try ((ffi/cfn "add_numbers" [::mem/int ::mem/bool] ::mem/int) 2 :truthy) false (catch Exception _ true))
+    (try ((ffi/cfn "add_numbers" [::mem/int ::mem/int] ::mem/bool) 2 2) false (catch Exception _ true)))))
+
 (mem/defalias ::point
   [::mem/struct
    [[:x ::mem/float]

--- a/test/clj/coffi/ffi_test.clj
+++ b/test/clj/coffi/ffi_test.clj
@@ -14,6 +14,15 @@
 (t/deftest can-call-primitive-fns
   (t/is (= 5 ((ffi/cfn "add_numbers" [::mem/int ::mem/int] ::mem/int) 2 3))))
 
+(t/deftest can-call-with-bool-argument
+  (t/is (= 1 ((ffi/cfn "add_numbers" [::mem/int [::mem/bool 32]] ::mem/int) 2 :truthy))))
+
+(t/deftest can-call-with-bool-return
+  (t/is
+   (and
+    (= true ((ffi/cfn "add_numbers" [::mem/int ::mem/int] [::mem/bool 32]) 2 2))
+    (= false ((ffi/cfn "add_numbers" [::mem/int ::mem/int] [::mem/bool 32]) 2 -2)))))
+
 (mem/defalias ::point
   [::mem/struct
    [[:x ::mem/float]

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -1,6 +1,7 @@
 (ns coffi.mem-test
   (:require
    [clojure.test :as t]
+   [clojure.set :as s]
    [coffi.ffi :as ffi]
    [coffi.mem :as mem])
   (:import
@@ -183,6 +184,18 @@
         (mem/deserialize-from bool-16-segment [::mem/bool 16])
         (not (mem/deserialize-from bool-32-segment [::mem/bool 32]))
         (mem/deserialize-from bool-64-segment [::mem/bool 64])))))
+
+(t/deftest bool-array-serializes
+  (t/is
+   (and
+    (= (s/union (set (range 0 8)) (set (range 16 24)))
+       (mem/deserialize-from
+        (mem/serialize [true false true false] [::mem/array [::mem/bool 8] 4])
+        [::mem/flagset (vec (range 32))]))
+    (= (set (range 16 32))
+       (mem/deserialize-from
+        (mem/serialize [false true] [::mem/array [::mem/bool 16] 2])
+        [::mem/flagset (vec (range 32))])))))
 
 (t/deftest unsized-bool-throws
   (t/is

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -133,3 +133,53 @@
       (mem/serialize ::ComplexTestTypeWrapped)
       (mem/deserialize ::ComplexTestTypeWrapped)))))
 
+(t/deftest can-serialize-false-to-bool
+  (t/is
+   (= 0
+      (mem/serialize nil [::mem/bool 8])
+      (mem/serialize false [::mem/bool 16])
+      (mem/serialize nil [::mem/bool 32])
+      (mem/serialize false [::mem/bool 64]))))
+
+(t/deftest can-serialize-true-to-bool
+  (t/is
+   (= -1
+      (mem/serialize :true [::mem/bool 8])
+      (mem/serialize true [::mem/bool 16])
+      (mem/serialize 1000 [::mem/bool 32])
+      (mem/serialize "str" [::mem/bool 64]))))
+
+(t/deftest can-serialize-into-bool
+  (t/is
+   (let [bool-8-segment (mem/alloc-instance [::mem/bool 8])
+         bool-16-segment (mem/alloc-instance [::mem/bool 16])
+         bool-32-segment (mem/alloc-instance [::mem/bool 32])
+         bool-64-segment (mem/alloc-instance [::mem/bool 64])
+
+         _ (mem/serialize-into :true [::mem/bool 8]  bool-8-segment  nil)
+         _ (mem/serialize-into true  [::mem/bool 16] bool-16-segment nil)
+         _ (mem/serialize-into 1000  [::mem/bool 32] bool-32-segment nil)
+         _ (mem/serialize-into "str" [::mem/bool 64] bool-64-segment nil)
+         ]
+     (= -1
+        (mem/read-byte bool-8-segment)
+        (mem/read-short bool-16-segment)
+        (mem/read-int bool-32-segment)
+        (mem/read-long bool-64-segment)))))
+
+(t/deftest can-deserialize-from-bool
+  (t/is
+   (let [bool-8-segment (mem/alloc-instance [::mem/bool 8])
+         bool-16-segment (mem/alloc-instance [::mem/bool 16])
+         bool-32-segment (mem/alloc-instance [::mem/bool 32])
+         bool-64-segment (mem/alloc-instance [::mem/bool 64])
+
+         _ (mem/write-byte bool-8-segment 1)
+         _ (mem/write-short bool-16-segment -1)
+         _ (mem/write-int bool-32-segment 0)
+         _ (mem/write-long bool-64-segment 42)]
+     (= true
+        (mem/deserialize-from bool-8-segment [::mem/bool 8])
+        (mem/deserialize-from bool-16-segment [::mem/bool 16])
+        (not (mem/deserialize-from bool-32-segment [::mem/bool 32]))
+        (mem/deserialize-from bool-64-segment [::mem/bool 64])))))

--- a/test/clj/coffi/mem_test.clj
+++ b/test/clj/coffi/mem_test.clj
@@ -183,3 +183,10 @@
         (mem/deserialize-from bool-16-segment [::mem/bool 16])
         (not (mem/deserialize-from bool-32-segment [::mem/bool 32]))
         (mem/deserialize-from bool-64-segment [::mem/bool 64])))))
+
+(t/deftest unsized-bool-throws
+  (t/is
+   (and
+    (try (mem/alloc-instance ::mem/bool) false (catch Exception _ true))
+    (try (mem/serialize :test ::mem/bool) false (catch Exception _ true)))))
+


### PR DESCRIPTION
Hi, In this pull request I propose adding boolean support to coffi via the built in boolean support from the new Java 22 FFI API.

One thing to consider with respect to boolean support is how this is implemented for different platforms and look at how the JVM defines booleans in this context. A stable C-API is desireable and booleans are notoriously an issue in this regard, so this before merging this PR these concerns have to be adressed.

For this reason I consider this PR a draft PR for the start.