### PR TITLE
Update tools.build and nix flake

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -34,7 +34,8 @@
                       :source-uri "https://github.com/IGJoshua/coffi/blob/{git-commit}/{filepath}#L{line}"
                       :metadata {:doc/format :markdown}}}
 
-  :build {:replace-deps {org.clojure/clojure {:mvn/version "1.12.4"}
+  :build {:extra-paths ["."]
+          :replace-deps {org.clojure/clojure {:mvn/version "1.12.4"}
                          io.github.clojure/tools.build {:mvn/version "0.10.13"}}
           :ns-default build
           :exec-fn run-tasks}

--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
 
  :aliases
  {:dev {:extra-paths ["."]
-        :extra-deps {io.github.clojure/tools.build {:git/tag "v0.3.0" :git/sha "e418fc9"}
+        :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.13"}
                      nodisassemble/nodisassemble {:mvn/version "0.1.3"}
                      criterium/criterium {:mvn/version "0.4.6"}}
         ;; NOTE(Joshua): If you want to use nodisassemble you should also add a
@@ -34,8 +34,8 @@
                       :source-uri "https://github.com/IGJoshua/coffi/blob/{git-commit}/{filepath}#L{line}"
                       :metadata {:doc/format :markdown}}}
 
-  :build {:replace-deps {org.clojure/clojure {:mvn/version "1.10.3"}
-                         io.github.clojure/tools.build {:git/tag "v0.3.0" :git/sha "e418fc9"}}
+  :build {:replace-deps {org.clojure/clojure {:mvn/version "1.12.4"}
+                         io.github.clojure/tools.build {:mvn/version "0.10.13"}}
           :ns-default build
           :exec-fn run-tasks}
   :install {:replace-deps {slipset/deps-deploy {:mvn/version "0.1.5"}}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727634051,
-        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
+        "lastModified": 1774106199,
+        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
+        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
         inherit system;
         overlays = [
           (final: prev: {
-            clojure = prev.clojure.override { jdk = final.jdk22; };
+            clojure = prev.clojure.override { jdk = final.jdk25; };
           })
         ];
       };


### PR DESCRIPTION
Using clojure/tools.build from git deps can be problematic in some
environments. This commit updates to the latest version, and takes
advantage of the fact that it is distributed on maven.

The required clojure version was also updated (required by latest tools.build).

In `:build` i also  add `.` to the classpath so that `build.clj` is visible when running the prep step. This is needed when doing nix builds with tools like clj-nix or clojure-nix-locker.

Finally, I also updated the nix flake inputs to make the devshell again.
